### PR TITLE
Automation: release to cocoapods

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release to CocoaPods
+
+on:
+  release:
+    types: [published, prereleased]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache bundler
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: bundler-${{ hashFiles('Gemfile.lock') }}
+        restore-keys: |
+          bundler-${{ hashFiles('Gemfile.lock') }}
+
+    - name: Setup
+      run: |
+        bundle
+
+    - name: Lint
+      run: make lint
+
+    - name: Deploy to CocoaPods
+      env:
+        COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+      run: make release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release to CocoaPods
 
 on:
   release:
-    types: [published, prereleased]
+    types: [prereleased]
 
 jobs:
   build:
@@ -22,6 +22,9 @@ jobs:
     - name: Setup
       run: |
         bundle
+
+    - name: Test
+      run: make test
 
     - name: Lint
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint: ## cocoapods - lint podspec
 
 .PHONY: release
 release: ## cocoapods - release
-	bundle exec pod trunk push SwiftPrettyPrint
+	bundle exec pod trunk push SwiftPrettyPrint.podspec
 
 .PHONY: info
 info: ## cocoapods - show trunk information

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint: ## cocoapods - lint podspec
 
 .PHONY: release
 release: ## cocoapods - release
-	bundle exec pod trunk push
+	bundle exec pod trunk push SwiftPrettyPrint
 
 .PHONY: info
 info: ## cocoapods - show trunk information

--- a/SwiftPrettyPrint.podspec
+++ b/SwiftPrettyPrint.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |spec|
   spec.name         = "SwiftPrettyPrint"
-  spec.version      = "0.0.2"
+  spec.version      = "0.0.3"
   spec.summary      = "Pretty print for debug in Swift"
   spec.description  = <<-DESC
   SwiftPrettyPrint is a library for debug in Swift.


### PR DESCRIPTION
Release to CocoaPods via GitHub Actions that triggered by `pre-release`.

## Triggered
https://github.com/YusukeHosonuma/SwiftPrettyPrint/releases/tag/0.0.3
![image](https://user-images.githubusercontent.com/2990285/75000595-21fec000-54a2-11ea-8549-3cc3b6c215f3.png)

## Run Release workflow
https://github.com/YusukeHosonuma/SwiftPrettyPrint/runs/459338542
![image](https://user-images.githubusercontent.com/2990285/75000564-0a273c00-54a2-11ea-8361-5e12c46bc52d.png)

## Reference
https://qiita.com/ry-itto/items/0fab3fdc4321bfbd3877#%E3%81%8A%E3%81%BE%E3%81%91

## Remarks
Version `0.0.3` is deleted from [CocoaPods - SwiftPrettyPrint](https://cocoapods.org/pods/SwiftPrettyPrint), because this is test release.