### PR TITLE
Support URL debug print

### DIFF
--- a/Sources/Core/Pretty.swift
+++ b/Sources/Core/Pretty.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 class Pretty {
     private var indent: Int { Debug.option.indent }
 
@@ -71,6 +73,12 @@ class Pretty {
         let typeName = String(describing: mirror.subjectType)
 
         let prefix = "\(typeName)("
+        
+        if typeName == "URL" {
+            let field = mirror.children.first?.value as! NSURL
+            return prefix + "\"" + field.absoluteString! + "\"" + ")"
+        }
+
         let fields = mirror.children.map {
             "\($0.label ?? "-"): " + _string($0.value)
         }

--- a/Tests/Core/PrettyTests.swift
+++ b/Tests/Core/PrettyTests.swift
@@ -57,15 +57,12 @@ class PrettyTests: XCTestCase {
 
         //
         // URL
-        // TODO: https://github.com/YusukeHosonuma/SwiftPrettyPrint/issues/23
         //
 
         XCTAssertEqual(pretty.string(URL(string: "https://www.google.com/")!, debug: false, pretty: false),
                        "https://www.google.com/")
-
-        // FIXME: this test has failed currently
-        // XCTAssertEqual(pretty.string(URL(string: "https://www.google.com/")!, debug: true, pretty: false),
-        //               #"URL("https://www.google.com/")"#)
+        XCTAssertEqual(pretty.string(URL(string: "https://www.google.com/")!, debug: true, pretty: false),
+                       #"URL("https://www.google.com/")"#)
 
         // TODO: add test pattern
     }


### PR DESCRIPTION
Now debug-print string of URL instances is as we expected: 

```swift
pretty.string(URL(string: "https://www.google.com/")!, debug: true)
// => URL("https://www.google.com/")
```

fixed #23 .

## description of changes

- add dependency of Foundation for `NSURL`.
- add URL-specific implementation for `Pretty.string()` method.

## Tests

It passes all unit test cases.