### PR TITLE
CI: run tests are execution in parallel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,27 @@ on:
     types: [prereleased]
 
 jobs:
-  release:
+  unit-test:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Run Unit Test
+      run: make test
+
+    - name: Write result
+      if: always()
+      run: echo ${{ job.status }} > job-result.txt
+
+    - name: Upload job result for job slack-notify
+      if: always()
+      uses: actions/upload-artifact@v1
+      with:
+        name: result
+        path: job-result.txt
+
+  integration-test:
     runs-on: macos-latest
 
     steps:
@@ -16,17 +36,41 @@ jobs:
       with:
         path: vendor/bundle
         key: bundler-${{ hashFiles('Gemfile.lock') }}
-        restore-keys: |
-          bundler-${{ hashFiles('Gemfile.lock') }}
+        restore-keys: bundler-${{ hashFiles('Gemfile.lock') }}
 
-    - name: Setup
+    - name: Bundle install
       run: bundle
-
-    - name: Run Unit Test
-      run: make test
 
     - name: Run Integration Test
       run: make integration-test
+
+    - name: Write result
+      if: always()
+      run: echo ${{ job.status }} > job-result.txt
+
+    - name: Upload job result for job slack-notify
+      if: always()
+      uses: actions/upload-artifact@v1
+      with:
+        name: result
+        path: job-result.txt
+
+  deploy:
+    runs-on: macos-latest
+    needs: [unit-test, integration-test]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache bundler
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: bundler-${{ hashFiles('Gemfile.lock') }}
+        restore-keys: bundler-${{ hashFiles('Gemfile.lock') }}
+
+    - name: Setup
+      run: bundle
 
     - name: Lint
       run: make lint
@@ -49,7 +93,7 @@ jobs:
 
   slack-notify:
     runs-on: ubuntu-latest
-    needs: release
+    needs: deploy
     if: always()
 
     steps:


### PR DESCRIPTION
resolved #39 

Improve release-workflow that run unit-test and integration-test are execution in parallel.

## Workflows

Job execution flow are looks like following:

```
unit-test ----------+
integration-test ---+---> deploy ------> slack-notify
```

## Screenshots

| [Failed in integration-test](https://github.com/YusukeHosonuma/SwiftPrettyPrint/actions/runs/44695710) | [Failed in deploy](https://github.com/YusukeHosonuma/SwiftPrettyPrint/actions/runs/44705197) |
|----------------------------|------------------|
| ![image](https://user-images.githubusercontent.com/2990285/75216650-0ebc5f00-57d8-11ea-9001-263e01589f2e.png) | ![image](https://user-images.githubusercontent.com/2990285/75217256-d3229480-57d9-11ea-921e-e9331e4368d2.png) |


