### PR TITLE
API: perfect safety

### DIFF
--- a/Sources/Core/Pretty.swift
+++ b/Sources/Core/Pretty.swift
@@ -174,14 +174,15 @@ struct Pretty {
 
     func dumpError(error: Error) {
         let message = """
+        
         ---------------------------------------------------------
         Fatal error in SwiftPrettyPrint.
         ---------------------------------------------------------
-        Detail: \(error.localizedDescription)
-
+        \(error.localizedDescription)
         Please report issue from below:
         https://github.com/YusukeHosonuma/SwiftPrettyPrint/issues
         ---------------------------------------------------------
+        
         """
         print(message)
     }

--- a/Sources/Core/Pretty.swift
+++ b/Sources/Core/Pretty.swift
@@ -16,7 +16,12 @@ struct Pretty {
         }
 
         func _value(_ target: Any) -> String {
-            valueString(target, debug: debug) // fixed `debug`
+            do {
+                return try valueString(target, debug: debug) // fixed `debug`
+            } catch {
+                dumpError(error: error)
+                return "\(error)"
+            }
         }
 
         let mirror = Mirror(reflecting: target)
@@ -39,22 +44,27 @@ struct Pretty {
             }
 
         case .dictionary:
-            if pretty {
-                let contents = extractKeyValues(from: target).map { key, val in
-                    let label = _value(key)
-                    let value = _string(val).indentTail(size: "\(label): ".count)
-                    return "\(label): \(value)"
-                }.sorted().joined(separator: ",\n")
+            do {
+                if pretty {
+                    let contents = try extractKeyValues(from: target).map { key, val in
+                        let label = _value(key)
+                        let value = _string(val).indentTail(size: "\(label): ".count)
+                        return "\(label): \(value)"
+                    }.sorted().joined(separator: ",\n")
 
-                return "[\n\(contents.indent(size: indent))\n]"
-            } else {
-                let contents = extractKeyValues(from: target).map { key, val in
-                    let label = _value(key)
-                    let value = _string(val)
-                    return "\(label): \(value)"
-                }.sorted().joined(separator: ", ")
+                    return "[\n\(contents.indent(size: indent))\n]"
+                } else {
+                    let contents = try extractKeyValues(from: target).map { key, val in
+                        let label = _value(key)
+                        let value = _string(val)
+                        return "\(label): \(value)"
+                    }.sorted().joined(separator: ", ")
 
-                return "[\(contents)]"
+                    return "[\(contents)]"
+                }
+            } catch {
+                dumpError(error: error)
+                return "\(error)"
             }
 
         default:
@@ -77,8 +87,13 @@ struct Pretty {
         let prefix = "\(typeName)("
 
         if typeName == "URL" {
-            let field = mirror.children.first?.value as! NSURL
-            return prefix + "\"" + field.absoluteString! + "\"" + ")"
+            do {
+                let string = try urlString(target)
+                return prefix + string + ")"
+            } catch {
+                dumpError(error: error)
+                return "\(error)"
+            }
         }
 
         let fields = mirror.children.map {
@@ -95,13 +110,24 @@ struct Pretty {
 
     // MARK: - util
 
-    func valueString<T>(_ target: T, debug: Bool) -> String {
+    func urlString(_ target: Any) throws -> String {
+        let mirror = Mirror(reflecting: target)
+
+        guard
+            let field = mirror.children.first?.value as? NSURL,
+            let urlString = field.absoluteString else {
+            throw PrettyError.unknownError(target: target)
+        }
+
+        return #""\#(urlString)""#
+    }
+
+    func valueString<T>(_ target: T, debug: Bool) throws -> String {
         let mirror = Mirror(reflecting: target)
 
         // Note: this function currently supports Optional type that includes a child.
         guard mirror.children.count <= 1 else {
-            // TODO: change to safe-api when official release
-            preconditionFailure("valueString() is must value that not has members")
+            throw PrettyError.unknownError(target: target)
         }
 
         switch target {
@@ -127,12 +153,12 @@ struct Pretty {
             }
 
         default:
-            preconditionFailure("Not supported type")
+            throw PrettyError.notSupported(target: target)
         }
     }
 
-    func extractKeyValues(from dictionary: Any) -> [(Any, Any)] {
-        Mirror(reflecting: dictionary).children.map {
+    func extractKeyValues(from dictionary: Any) throws -> [(Any, Any)] {
+        try Mirror(reflecting: dictionary).children.map {
             // Note:
             // Each element $0 structure are like following:
             //
@@ -148,10 +174,24 @@ struct Pretty {
             guard
                 let key = root.children.first?.value,
                 let value = root.children.dropFirst().first?.value else {
-                preconditionFailure("Extract key or value is failed.")
+                throw PrettyError.failedExtractKeyValue(dictionary: dictionary)
             }
 
             return (key, value)
         }
+    }
+
+    func dumpError(error: Error) {
+        let message = """
+        ---------------------------------------------------------
+        Fatal error in SwiftPrettyPrint.
+        ---------------------------------------------------------
+        Detail: \(error.localizedDescription)
+
+        Please report issue from below:
+        https://github.com/YusukeHosonuma/SwiftPrettyPrint/issues
+        ---------------------------------------------------------
+        """
+        print(message)
     }
 }

--- a/Sources/Core/PrettyError.swift
+++ b/Sources/Core/PrettyError.swift
@@ -17,14 +17,20 @@ extension PrettyError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case let .notSupported(target: target):
-            return "Not supported value. (\(target))"
+            return "Not supported:\n\(dumpString(target))"
 
         case let .failedExtractKeyValue(target):
-            return "Extract key or value is failed. (\(target))"
+            return "Extract key or value is failed:\n\(dumpString(target))"
 
         case let .unknownError(target: target):
-            return "Unknown error. (\(target))"
+            return "Unknown error:\n\(dumpString(target))"
         }
+    }
+
+    func dumpString(_ target: Any) -> String {
+        var string: String = ""
+        dump(target, to: &string)
+        return string
     }
 }
 

--- a/Sources/Core/PrettyError.swift
+++ b/Sources/Core/PrettyError.swift
@@ -1,0 +1,41 @@
+//
+//  PrettyError.swift
+//  SwiftPrettyPrint
+//
+//  Created by Yusuke Hosonuma on 2020/02/25.
+//
+
+import Foundation
+
+enum PrettyError: Error {
+    case notSupported(target: Any)
+    case failedExtractKeyValue(dictionary: Any)
+    case unknownError(target: Any)
+}
+
+extension PrettyError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case let .notSupported(target: target):
+            return "Not supported value. (\(target))"
+
+        case let .failedExtractKeyValue(target):
+            return "Extract key or value is failed. (\(target))"
+
+        case let .unknownError(target: target):
+            return "Unknown error. (\(target))"
+        }
+    }
+}
+
+extension PrettyError: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .notSupported:
+            return "<< not supported >>"
+
+        case .failedExtractKeyValue, .unknownError:
+            return "<< unknown error >>"
+        }
+    }
+}

--- a/SwiftPrettyPrint.xcodeproj/project.pbxproj
+++ b/SwiftPrettyPrint.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		E5222E5E2405141000C68300 /* PrettyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5222E5D2405141000C68300 /* PrettyError.swift */; };
 		E522E35623FFB58A00C42B78 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = E522E35523FFB58A00C42B78 /* Option.swift */; };
 		E522E35823FFB5C400C42B78 /* OptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E522E35723FFB5C400C42B78 /* OptionTests.swift */; };
 		E522F4EB23FE6BDC007AD28A /* String+extensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E522F4EA23FE6BDC007AD28A /* String+extensionTests.swift */; };
@@ -52,6 +53,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		E5222E5D2405141000C68300 /* PrettyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyError.swift; sourceTree = "<group>"; };
 		E522E35523FFB58A00C42B78 /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
 		E522E35723FFB5C400C42B78 /* OptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionTests.swift; sourceTree = "<group>"; };
 		E522F4EA23FE6BDC007AD28A /* String+extensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extensionTests.swift"; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_10 /* Pretty.swift */,
+				E5222E5D2405141000C68300 /* PrettyError.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -274,6 +277,7 @@
 			buildActionMask = 0;
 			files = (
 				E522E35623FFB58A00C42B78 /* Option.swift in Sources */,
+				E5222E5E2405141000C68300 /* PrettyError.swift in Sources */,
 				OBJ_31 /* Debug.swift in Sources */,
 				OBJ_32 /* Pretty.swift in Sources */,
 				OBJ_33 /* String+extension.swift in Sources */,

--- a/Tests/Core/PrettyTests.swift
+++ b/Tests/Core/PrettyTests.swift
@@ -242,7 +242,7 @@ class PrettyTests: XCTestCase {
             "Two": 2,
         ]
 
-        let result = pretty.extractKeyValues(from: dictionary) as? [(String, Int)]
+        let result = try pretty.extractKeyValues(from: dictionary) as? [(String, Int)]
 
         // Note:
         // XCTUnwrap is not supported Swift Package Manager currently.


### PR DESCRIPTION
Remove all codes that could cause a crash (e.g. `!` or `preconditionFailure` and others).

Tips:
This PR is include change white-space, therefore with `w=1` is helpful for review:
https://github.com/YusukeHosonuma/SwiftPrettyPrint/pull/48/files?w=1

## Example
When cause error in `URL` type:

```swift
let url = URL(string: "https://www.google.com/")!
Debug.debugPrint([url]) // => [<< unknown error >>]
// =>
// ---------------------------------------------------------
// Fatal error in SwiftPrettyPrint.
// ---------------------------------------------------------
// Unknown error:
// ▿ https://www.google.com/
//   - _url: https://www.google.com/ #0
//     - super: NSObject
//
// Please report issue from below:
// https://github.com/YusukeHosonuma/SwiftPrettyPrint/issues
// ---------------------------------------------------------
//
// [<< unknown error >>]
```