### PR TITLE
CI: only execute when `master` branch on `push` event trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   unit-test:


### PR DESCRIPTION
Ref: https://help.github.com/ja/actions/reference/events-that-trigger-workflows

## on PR
![image](https://user-images.githubusercontent.com/2990285/75310045-28bc7700-5896-11ea-9120-ee01cb53018d.png)

## on push to `master`
![image](https://user-images.githubusercontent.com/2990285/75310150-7507b700-5896-11ea-8ca9-791d25c970b1.png)
