### PR TITLE
Improve: code coverage - goodbye `xcodebuild`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,19 +16,13 @@ jobs:
     - name: Run Unit Test
       run: make test
 
-    # Note:
-    # Test is executed in two times.
-    # There should be a better way.
-    #
-    # Ref: https://github.com/codecov/example-swift
-    - name: Test for coverage
+    - name: Convert coverage file
       run: |
-        xcodebuild \
-          -scheme SwiftPrettyPrint-Package \
-          -project SwiftPrettyPrint.xcodeproj \
-          -sdk iphonesimulator \
-          -destination 'platform=iOS Simulator,name=iPhone 11' \
-          test
+        xcrun llvm-cov export \
+            .build/debug/SwiftPrettyPrintPackageTests.xctest/Contents/MacOS/SwiftPrettyPrintPackageTests \
+            -instr-profile .build/debug/codecov/default.profdata \
+            -ignore-filename-regex=".build|Tests" \
+            -format="lcov" > info.lcov
 
     - name: Upload to codecov.io
       run: bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ build: ## swift - build
 	swift build
 
 .PHONY: test
-test: ## swift - test
-	swift test
+test: ## swift - test (with coverage)
+	swift test --enable-code-coverage
 
 .PHONY: xcode
 xcode: ## swift - generate xcode project

--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -34,12 +34,15 @@ class MultilineFormatter: PrettyFormatter {
 
     func objectString(typeName: String, fields: [(String, String)]) -> String {
         let prefix = "\(typeName)("
+        let body: String
 
         if fields.count == 1, let field = fields.first {
-            return prefix + "\(field.0): \(field.1)" + ")"
+            body = "\(field.0): \(field.1)"
         } else {
             let contents = fields.map { "\($0): \($1)" }.joined(separator: ",\n")
-            return prefix + contents.indentTail(size: prefix.count) + ")"
+            body = contents.indentTail(size: prefix.count)
         }
+
+        return prefix + body + ")"
     }
 }


### PR DESCRIPTION
Gather code coverage by `swift test --enable-code-coverage` instead of `xcodebuild`, it means not dependence to Xcode projects.

And petit refactor :)

## TODO
- [x] change destination to `master`