### PR TITLE
fix indention of values which are object and have multiple member

### DIFF
--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -62,8 +62,7 @@ class MultilineFormatter: PrettyFormatter {
     ///
     /// - Parameter source: key value pair
     private func indentInsertedKeyValueString(_ source: (String, String)) -> String {
-        let indentInsertedNewLineCharactor = "\n" + String(repeating: " ", count: "\(source.0): ".count)
-        let indentInserted = source.1.replacingOccurrences(of: "\n", with: indentInsertedNewLineCharactor)
+        let indentInserted = source.1.indentTail(size: "\(source.0): ".count)
         return "\(source.0): \(indentInserted)"
     }
 }

--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -38,8 +38,28 @@ class MultilineFormatter: PrettyFormatter {
         if fields.count == 1, let field = fields.first {
             return prefix + "\(field.0): \(field.1)" + ")"
         } else {
-            let contents = fields.map { "\($0): \($1)" }.joined(separator: ",\n")
+            let contents = fields.map(indentInsertedKeyValueString(_:)).joined(separator: ",\n")
             return prefix + contents.indentTail(size: prefix.count) + ")"
         }
+    }
+
+    /// transform key value pair to single string inserted indent according to key
+    ///
+    /// ex:
+    /// ("owner", """
+    /// Owner(name: "Nanachi",
+    ///       age: 4)
+    /// """)
+    ///
+    /// goes to
+    ///
+    /// owner: Owner(name: "Nanachi",
+    ///              age: 4))
+    ///
+    /// - Parameter source: key value pair
+    private func indentInsertedKeyValueString(_ source: (String, String)) -> String {
+        let indentInsertedNewLineCharactor = "\n" + String(repeating: " ", count: "\(source.0): ".count)
+        let indentInserted = source.1.replacingOccurrences(of: "\n", with: indentInsertedNewLineCharactor)
+        return "\(source.0): \(indentInserted)"
     }
 }

--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -39,7 +39,9 @@ class MultilineFormatter: PrettyFormatter {
         if fields.count == 1, let field = fields.first {
             body = "\(field.0): \(field.1)"
         } else {
-            body = fields.map(indentInsertedKeyValueString(_:)).joined(separator: ",\n")
+            body = fields.map(indentInsertedKeyValueString(_:))
+                .joined(separator: ",\n")
+                .indentTail(size: prefix.count)
         }
 
         return prefix + body + ")"

--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -32,22 +32,9 @@ class MultilineFormatter: PrettyFormatter {
         """
     }
 
-    func objectString(typeName: String, fields: [(String, String)]) -> String {
-        let prefix = "\(typeName)("
-        let body: String
-
-        if fields.count == 1, let field = fields.first {
-            body = "\(field.0): \(field.1)"
-        } else {
-            body = fields.map(indentInsertedKeyValueString(_:))
-                .joined(separator: ",\n")
-                .indentTail(size: prefix.count)
-        }
-
-        return prefix + body + ")"
-    }
-
-    /// transform key value pair to single string inserted indent according to key
+    /// NOTE:
+    /// transform fields to single string
+    /// insert indent according to key
     ///
     /// ex:
     /// ("owner", """
@@ -60,9 +47,21 @@ class MultilineFormatter: PrettyFormatter {
     /// owner: Owner(name: "Nanachi",
     ///              age: 4))
     ///
-    /// - Parameter source: key value pair
-    private func indentInsertedKeyValueString(_ source: (label: String, value: String)) -> String {
-        let indentInserted = source.value.indentTail(size: "\(source.label): ".count)
-        return "\(source.label): \(indentInserted)"
+    func objectString(
+        typeName: String, fields: [(String, String)]
+    ) -> String {
+        let prefix = "\(typeName)("
+        let body: String
+
+        if fields.count == 1, let field = fields.first {
+            body = "\(field.0): \(field.1)"
+        } else {
+            body = fields
+                .map { label, value in "\(label): \(value.indentTail(size: "\(label): ".count))" }
+                .joined(separator: ",\n")
+                .indentTail(size: prefix.count)
+        }
+
+        return prefix + body + ")"
     }
 }

--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -61,8 +61,8 @@ class MultilineFormatter: PrettyFormatter {
     ///              age: 4))
     ///
     /// - Parameter source: key value pair
-    private func indentInsertedKeyValueString(_ source: (String, String)) -> String {
-        let indentInserted = source.1.indentTail(size: "\(source.0): ".count)
-        return "\(source.0): \(indentInserted)"
+    private func indentInsertedKeyValueString(_ source: (label: String, value: String)) -> String {
+        let indentInserted = source.value.indentTail(size: "\(source.label): ".count)
+        return "\(source.label): \(indentInserted)"
     }
 }

--- a/Tests/Core/Formatter/MultilineFormatterTests.swift
+++ b/Tests/Core/Formatter/MultilineFormatterTests.swift
@@ -77,14 +77,11 @@ class MultilineFormatterTests: XCTestCase {
         ]
 
         formatter = MultilineFormatter(option: Debug.Option(indent: 2))
-
-        // Bug: https://github.com/YusukeHosonuma/SwiftPrettyPrint/issues/25
-        //
-        // assertEqualLines(formatter.objectString(typeName: "Dog", fields: fields),
-        //                 """
-        //                 Dog(name: "pochi",
-        //                     owner: Owner(name: "Nanachi",
-        //                                  age: 4))
-        //                 """)
+         assertEqualLines(formatter.objectString(typeName: "Dog", fields: fields),
+                         """
+                         Dog(name: "pochi",
+                             owner: Owner(name: "Nanachi",
+                                          age: 4))
+                         """)
     }
 }


### PR DESCRIPTION
As title, I fixed indention for `objectString()` when the member is object and it has multiple members.

resolve #25 