### PR TITLE
feature: multiple-values and `separator`

### DIFF
--- a/Sources/API/Debug.swift
+++ b/Sources/API/Debug.swift
@@ -19,119 +19,127 @@ public class Debug {
 // MARK: Standard API
 
 extension Debug {
-    /// Output `target` to console.
+    /// Output `targets` to console.
     /// - Parameters:
-    ///   - target: target
+    ///   - targets: targets
     public static func print(
-        _ target: Any
+        _ targets: Any...
     ) {
-        Swift.print(_print(target))
+        Swift.print(_print(targets))
     }
 
-    /// Output `target` to `output`.
+    /// Output `targets` to `output`.
     /// - Parameters:
-    ///   - target: target
+    ///   - target: targets
     ///   - output: output
     public static func print<Target: TextOutputStream>(
-        _ target: Any,
+        _ targets: Any...,
         to output: inout Target
     ) {
-        Swift.print(_print(target), to: &output)
+        Swift.print(_print(targets), to: &output)
     }
 
-    /// Output pretty-formatted `target` to console.
+    /// Output pretty-formatted `targets` to console.
     /// - Parameters:
-    ///   - target: target
+    ///   - targets: targets
     ///   - option: option (default: `Debug.sharedOption`)
     public static func prettyPrint(
-        _ target: Any,
+        _ targets: Any...,
         option: Option = Debug.sharedOption
     ) {
-        Swift.print(_prettyPrint(target, option: option))
+        Swift.print(_prettyPrint(targets, option: option))
     }
 
-    /// Output pretty-formatted `target` to console.
+    /// Output pretty-formatted `targets` to console.
     /// - Parameters:
-    ///   - target: target
+    ///   - targets: targets
     ///   - option: option (default: `Debug.sharedOption`)
     ///   - output: output
     public static func prettyPrint<Target: TextOutputStream>(
-        _ target: Any,
+        _ targets: Any...,
         option: Option = Debug.sharedOption,
         to output: inout Target
     ) {
-        Swift.print(_prettyPrint(target, option: option), to: &output)
+        Swift.print(_prettyPrint(targets, option: option), to: &output)
     }
 
-    /// Output debuggable `target` to console.
+    /// Output debuggable `targets` to console.
     /// - Parameters:
-    ///   - target: target
+    ///   - targets: targets
     public static func debugPrint(
-        _ target: Any
+        _ targets: Any...
     ) {
-        Swift.print(_debugPrint(target))
+        Swift.print(_debugPrint(targets))
     }
 
-    /// Output debuggable `target` to console.
+    /// Output debuggable `targets` to console.
     /// - Parameters:
-    ///   - target: target
+    ///   - targets: targets
     ///   - output: output
     public static func debugPrint<Target: TextOutputStream>(
-        _ target: Any,
+        _ targets: Any...,
         to output: inout Target
     ) {
-        Swift.print(_debugPrint(target), to: &output)
+        Swift.print(_debugPrint(targets), to: &output)
     }
 
-    /// Output debuggable and pretty-formatted `target` to console.
+    /// Output debuggable and pretty-formatted `targets` to console.
     /// - Parameters:
-    ///   - target: target
+    ///   - targets: targets
     ///   - option: option (default: `Debug.sharedOption`)
     public static func debugPrettyPrint(
-        _ target: Any,
+        _ targets: Any...,
         option: Option = Debug.sharedOption
     ) {
-        Swift.print(_debugPrettyPrint(target, option: option))
+        Swift.print(_debugPrettyPrint(targets, option: option))
     }
 
     /// Output debuggable and pretty-formatted `target` to console.
     /// - Parameters:
-    ///   - target: target
+    ///   - targets: targets
     ///   - option: option (default: `Debug.sharedOption`)
     ///   - output: output
     public static func debugPrettyPrint<Target: TextOutputStream>(
-        _ target: Any,
+        _ targets: Any...,
         option: Option = Debug.sharedOption,
         to output: inout Target
     ) {
-        Swift.print(_debugPrettyPrint(target, option: option), to: &output)
+        Swift.print(_debugPrettyPrint(targets, option: option), to: &output)
     }
 
     // MARK: - private
 
     private static func _print(
-        _ target: Any
+        _ targets: [Any]
     ) -> String {
-        Pretty(formatter: SinglelineFormatter()).string(target, debug: false)
+        targets.map {
+            Pretty(formatter: SinglelineFormatter()).string($0, debug: false)
+        }.joined(separator: " ")
     }
 
     private static func _prettyPrint(
-        _ target: Any,
+        _ targets: [Any],
         option: Option
     ) -> String {
-        Pretty(formatter: MultilineFormatter(option: option)).string(target, debug: false)
+        targets.map {
+            Pretty(formatter: MultilineFormatter(option: option)).string($0, debug: false)
+        }.joined(separator: ",\n")
     }
 
     private static func _debugPrint(
-        _ target: Any
+        _ targets: [Any]
     ) -> String {
-        Pretty(formatter: SinglelineFormatter()).string(target, debug: true)
+        targets.map {
+            Pretty(formatter: SinglelineFormatter()).string($0, debug: true)
+        }.joined(separator: " ")
     }
 
     private static func _debugPrettyPrint(
-        _ target: Any,
+        _ targets: [Any],
         option: Option
     ) -> String {
-        Pretty(formatter: MultilineFormatter(option: option)).string(target, debug: true)
+        targets.map {
+            Pretty(formatter: MultilineFormatter(option: option)).string($0, debug: true)
+        }.joined(separator: ",\n")
     }
 }

--- a/Sources/API/Debug.swift
+++ b/Sources/API/Debug.swift
@@ -22,124 +22,144 @@ extension Debug {
     /// Output `targets` to console.
     /// - Parameters:
     ///   - targets: targets
+    ///   - separator: A string to print between each item.
     public static func print(
-        _ targets: Any...
+        _ targets: Any...,
+        separator: String = " "
     ) {
-        Swift.print(_print(targets))
+        Swift.print(_print(targets, separator: separator))
     }
 
     /// Output `targets` to `output`.
     /// - Parameters:
     ///   - target: targets
+    ///   - separator: A string to print between each item.
     ///   - output: output
     public static func print<Target: TextOutputStream>(
         _ targets: Any...,
+        separator: String = " ",
         to output: inout Target
     ) {
-        Swift.print(_print(targets), to: &output)
+        Swift.print(_print(targets, separator: separator), to: &output)
     }
 
     /// Output pretty-formatted `targets` to console.
     /// - Parameters:
     ///   - targets: targets
+    ///   - separator: A string to print between each item.
     ///   - option: option (default: `Debug.sharedOption`)
     public static func prettyPrint(
         _ targets: Any...,
+        separator: String = "\n",
         option: Option = Debug.sharedOption
     ) {
-        Swift.print(_prettyPrint(targets, option: option))
+        Swift.print(_prettyPrint(targets, separator: separator, option: option))
     }
 
     /// Output pretty-formatted `targets` to console.
     /// - Parameters:
     ///   - targets: targets
+    ///   - separator: A string to print between each item.
     ///   - option: option (default: `Debug.sharedOption`)
     ///   - output: output
     public static func prettyPrint<Target: TextOutputStream>(
         _ targets: Any...,
+        separator: String = "\n",
         option: Option = Debug.sharedOption,
         to output: inout Target
     ) {
-        Swift.print(_prettyPrint(targets, option: option), to: &output)
+        Swift.print(_prettyPrint(targets, separator: separator, option: option), to: &output)
     }
 
     /// Output debuggable `targets` to console.
     /// - Parameters:
     ///   - targets: targets
+    ///   - separator: A string to print between each item.
     public static func debugPrint(
-        _ targets: Any...
+        _ targets: Any...,
+        separator: String = " "
     ) {
-        Swift.print(_debugPrint(targets))
+        Swift.print(_debugPrint(targets, separator: separator))
     }
 
     /// Output debuggable `targets` to console.
     /// - Parameters:
     ///   - targets: targets
+    ///   - separator: A string to print between each item.
     ///   - output: output
     public static func debugPrint<Target: TextOutputStream>(
         _ targets: Any...,
+        separator: String = " ",
         to output: inout Target
     ) {
-        Swift.print(_debugPrint(targets), to: &output)
+        Swift.print(_debugPrint(targets, separator: separator), to: &output)
     }
 
     /// Output debuggable and pretty-formatted `targets` to console.
     /// - Parameters:
     ///   - targets: targets
+    ///   - separator: A string to print between each item.
     ///   - option: option (default: `Debug.sharedOption`)
     public static func debugPrettyPrint(
         _ targets: Any...,
+        separator: String = "\n",
         option: Option = Debug.sharedOption
     ) {
-        Swift.print(_debugPrettyPrint(targets, option: option))
+        Swift.print(_debugPrettyPrint(targets, separator: separator, option: option))
     }
 
     /// Output debuggable and pretty-formatted `target` to console.
     /// - Parameters:
     ///   - targets: targets
+    ///   - separator: A string to print between each item.
     ///   - option: option (default: `Debug.sharedOption`)
     ///   - output: output
     public static func debugPrettyPrint<Target: TextOutputStream>(
         _ targets: Any...,
+        separator: String = "\n",
         option: Option = Debug.sharedOption,
         to output: inout Target
     ) {
-        Swift.print(_debugPrettyPrint(targets, option: option), to: &output)
+        Swift.print(_debugPrettyPrint(targets, separator: separator, option: option), to: &output)
     }
 
     // MARK: - private
 
     private static func _print(
-        _ targets: [Any]
+        _ targets: [Any],
+        separator: String
     ) -> String {
         targets.map {
             Pretty(formatter: SinglelineFormatter()).string($0, debug: false)
-        }.joined(separator: " ")
+        }.joined(separator: separator)
     }
 
     private static func _prettyPrint(
         _ targets: [Any],
+        separator: String,
         option: Option
     ) -> String {
         targets.map {
             Pretty(formatter: MultilineFormatter(option: option)).string($0, debug: false)
-        }.joined(separator: ",\n")
+        }.joined(separator: separator)
     }
 
     private static func _debugPrint(
-        _ targets: [Any]
+        _ targets: [Any],
+        separator: String
     ) -> String {
         targets.map {
             Pretty(formatter: SinglelineFormatter()).string($0, debug: true)
-        }.joined(separator: " ")
+        }.joined(separator: separator)
     }
 
     private static func _debugPrettyPrint(
         _ targets: [Any],
+        separator: String,
         option: Option
     ) -> String {
         targets.map {
             Pretty(formatter: MultilineFormatter(option: option)).string($0, debug: true)
-        }.joined(separator: ",\n")
+        }.joined(separator: separator)
     }
 }

--- a/Tests/API/DebugTests.swift
+++ b/Tests/API/DebugTests.swift
@@ -192,8 +192,12 @@ class DebugTests: XCTestCase {
                          """ + "\n")
     }
     
-    func testMultipleValues() {
+    func testMultipleValuesAndSeparator() {
         let array = ["Hello", "World"]
+
+        //
+        // not specify `separator` (default)
+        //
         
         var result = ""
         Debug.print(array, 42, to: &result)
@@ -209,7 +213,7 @@ class DebugTests: XCTestCase {
             [
                 "Hello",
                 "World"
-            ],
+            ]
             42
             """ + "\n")
 
@@ -219,7 +223,39 @@ class DebugTests: XCTestCase {
             [
                 "Hello",
                 "World"
-            ],
+            ]
+            42
+            """ + "\n")
+        
+        //
+        // specify `separator`
+        //
+        
+        result = ""
+        Debug.print(array, 42, separator: "!!", to: &result)
+        XCTAssertEqual(result, #"["Hello", "World"]!!42"# + "\n")
+
+        result = ""
+        Debug.debugPrint(array, 42, separator: "!!", to: &result)
+        XCTAssertEqual(result, #"["Hello", "World"]!!42"# + "\n")
+
+        result = ""
+        Debug.prettyPrint(array, 42, separator: "!!\n", to: &result)
+        XCTAssertEqual(result, """
+            [
+                "Hello",
+                "World"
+            ]!!
+            42
+            """ + "\n")
+
+        result = ""
+        Debug.debugPrettyPrint(array, 42, separator: "!!\n", to: &result)
+        XCTAssertEqual(result, """
+            [
+                "Hello",
+                "World"
+            ]!!
             42
             """ + "\n")
     }

--- a/Tests/API/DebugTests.swift
+++ b/Tests/API/DebugTests.swift
@@ -33,14 +33,14 @@ class DebugTests: XCTestCase {
     override func setUp() {}
 
     override func tearDown() {}
-
+    
     func testPrint() {
         let expectString =
             #"Dog(id: "pochi", name: "ポチ", nickname: nil, age: 3, homepage: https://www.google.com/)"#
 
         let expectDebugString =
             #"Dog(id: DogId(rawValue: "pochi"), name: Optional("ポチ"), nickname: nil, age: 3, homepage: Optional(https://www.google.com/))"#
-
+        
         //
         // Struct
         //
@@ -190,5 +190,37 @@ class DebugTests: XCTestCase {
                                           homepage: Optional(https://www.google.com/))
                          ]
                          """ + "\n")
+    }
+    
+    func testMultipleValues() {
+        let array = ["Hello", "World"]
+        
+        var result = ""
+        Debug.print(array, 42, to: &result)
+        XCTAssertEqual(result, #"["Hello", "World"] 42"# + "\n")
+
+        result = ""
+        Debug.debugPrint(array, 42, to: &result)
+        XCTAssertEqual(result, #"["Hello", "World"] 42"# + "\n")
+
+        result = ""
+        Debug.prettyPrint(array, 42, to: &result)
+        XCTAssertEqual(result, """
+            [
+                "Hello",
+                "World"
+            ],
+            42
+            """ + "\n")
+
+        result = ""
+        Debug.debugPrettyPrint(array, 42, to: &result)
+        XCTAssertEqual(result, """
+            [
+                "Hello",
+                "World"
+            ],
+            42
+            """ + "\n")
     }
 }

--- a/Tests/Helper/Util.swift
+++ b/Tests/Helper/Util.swift
@@ -10,8 +10,3 @@ func uncurry<T1, T2, R>(_ f: @escaping (T1) -> (T2) -> R) -> (T1, T2) -> R {
         f(t1)(t2)
     }
 }
-func uncurry<T1, R>(_ f: @escaping (T1) -> () -> R) -> (T1) -> R {
-    { (t1) -> R in
-        f(t1)()
-    }
-}

--- a/Tests/Helper/Util.swift
+++ b/Tests/Helper/Util.swift
@@ -10,3 +10,8 @@ func uncurry<T1, T2, R>(_ f: @escaping (T1) -> (T2) -> R) -> (T1, T2) -> R {
         f(t1)(t2)
     }
 }
+func uncurry<T1, R>(_ f: @escaping (T1) -> () -> R) -> (T1) -> R {
+    { (t1) -> R in
+        f(t1)()
+    }
+}


### PR DESCRIPTION
Support multiple-values to output like [print](https://developer.apple.com/documentation/swift/1541053-print) of standard library.

## Example

```swift
print("Hello", 42)
// => "Hello" 42

Debug.print("Hello", 42)
// =>  "Hello" 42

Debug.print("Hello", 42, separator: ", ") // use custom `separator`
// =>  "Hello", 42

Debug.prettyPrint(["Hello", "World"], 42)
// =>
// [
//     "Hello",
//     "World"
// ]
// 42
```

## Limitation

Operator based API such as `Debug.p >>>` is not supported multiple values. Because **operator must have one or two arguments**, this is limitation of Swift.

![image](https://user-images.githubusercontent.com/2990285/76694599-1b85f180-66b8-11ea-934f-74dba7eb8868.png)

## Related
#76 