### PR TITLE
support: enum that associated value is many or labeled

### DIFF
--- a/Sources/Core/Pretty.swift
+++ b/Sources/Core/Pretty.swift
@@ -178,7 +178,23 @@ struct Pretty {
                 throw PrettyError.unknownError(target: target)
             }
 
-            return "\(prefix)(" + string(childValue, debug: debug) + ")"
+            var body = string(childValue, debug: debug)
+
+            // Note:
+            //
+            // Remove enclosed parenthese when `childValue` are tuple.
+            // (representation as `tuple` when `enum` has two or more associated-value or labeled)
+            //
+            // e.g.
+            // - `Fruit.orange("みかん", 42)` - `body` is `("みかん", 42)` of tuple
+            // - `Fruit.orange(juicy: true)` - `body` is `(juicy: 42)` of tuple
+            //
+            if body.first == "(", body.last == ")" {
+                body.removeFirst()
+                body.removeLast()
+            }
+
+            return "\(prefix)(" + body + ")"
         }
     }
 

--- a/Sources/Core/Pretty.swift
+++ b/Sources/Core/Pretty.swift
@@ -182,7 +182,7 @@ struct Pretty {
 
             // Note:
             //
-            // Remove enclosed parenthese when `childValue` are tuple.
+            // Remove enclosed parentheses when `childValue` are tuple.
             // (representation as `tuple` when `enum` has two or more associated-value or labeled)
             //
             // e.g.
@@ -190,7 +190,7 @@ struct Pretty {
             // - `Fruit.orange(juicy: true)` - `body` is `(juicy: 42)` of tuple
             //
 
-            return "\(prefix)(" + body.removeEnclosedParenthese() + ")"
+            return "\(prefix)(" + body.removeEnclosedParentheses() + ")"
         }
     }
 

--- a/Sources/Core/Pretty.swift
+++ b/Sources/Core/Pretty.swift
@@ -178,7 +178,7 @@ struct Pretty {
                 throw PrettyError.unknownError(target: target)
             }
 
-            var body = string(childValue, debug: debug)
+            let body = string(childValue, debug: debug)
 
             // Note:
             //
@@ -189,12 +189,8 @@ struct Pretty {
             // - `Fruit.orange("みかん", 42)` - `body` is `("みかん", 42)` of tuple
             // - `Fruit.orange(juicy: true)` - `body` is `(juicy: 42)` of tuple
             //
-            if body.first == "(", body.last == ")" {
-                body.removeFirst()
-                body.removeLast()
-            }
 
-            return "\(prefix)(" + body + ")"
+            return "\(prefix)(" + body.removeEnclosedParenthese() + ")"
         }
     }
 

--- a/Sources/Extension/String+extension.swift
+++ b/Sources/Extension/String+extension.swift
@@ -23,7 +23,7 @@ extension String {
             .joined(separator: "\n")
     }
 
-    func removeEnclosedParenthese() -> String {
+    func removeEnclosedParentheses() -> String {
         var s = self
         if first == "(", last == ")" {
             s.removeFirst()

--- a/Sources/Extension/String+extension.swift
+++ b/Sources/Extension/String+extension.swift
@@ -22,4 +22,13 @@ extension String {
         return ([head] + lines.dropFirst().map { $0.indent(size: size) })
             .joined(separator: "\n")
     }
+
+    func removeEnclosedParenthese() -> String {
+        var s = self
+        if first == "(", last == ")" {
+            s.removeFirst()
+            s.removeLast()
+        }
+        return s
+    }
 }

--- a/Tests/Core/PrettyTests.swift
+++ b/Tests/Core/PrettyTests.swift
@@ -185,19 +185,22 @@ class PrettyTests: XCTestCase {
             enum Fruit {
                 case apple(String)       // has one
                 case orange(String, Int) // has many
+                case banana(juicy: Bool) // with label
             }
 
-            assert(to: curry(pretty.string)(Fruit.apple("りんご"))) {
-                args(false, expect: #".apple("りんご")"#)
-                args(true,  expect: #"Fruit.apple("りんご")"#)
+            assert(to: pretty.string) {
+                // has one
+                args((Fruit.apple("りんご"),      false), expect: #".apple("りんご")"#)
+                args((Fruit.apple("りんご"),      true),  expect: #"Fruit.apple("りんご")"#)
+
+                // has many (representation as a tuple)
+                args((Fruit.orange("みかん", 42), false), expect: #".orange("みかん", 42)"#)
+                args((Fruit.orange("みかん", 42), true),  expect: #"Fruit.orange("みかん", 42)"#)
+                
+                // with label (representation as a tuple)
+                args((Fruit.banana(juicy: true), false), expect: #".banana(juicy: true)"#)
+                args((Fruit.banana(juicy: true), true),  expect: #"Fruit.banana(juicy: true)"#)
             }
-            
-            // TODO: wait for support `tuple`
-            // ref: https://github.com/YusukeHosonuma/SwiftPrettyPrint/issues/34
-            //
-            // fruit = .orange("みかん", 42)
-            // XCTAssertEqual(pretty.string(fruit, debug: false),
-            //                #".orange("みかん", 42)"#)
         }
         
         // nested-enum
@@ -218,18 +221,18 @@ class PrettyTests: XCTestCase {
             }
 
             assert(to: pretty.string) {
-                args((Fruit.apple(.sweet),       false), expect: ".apple(.sweet)")
-                args((Fruit.apple(.sweet),       true),  expect: "Fruit.apple(Taste.sweet)")
-                args((Fruit.apple(.sour(.high)), false), expect: ".apple(.sour(.high))")
-                args((Fruit.apple(.sour(.high)), true),  expect: "Fruit.apple(Taste.sour(Level.high))")
-            }
+                // nested one
+                args((Fruit.apple(.sweet),              false), expect: ".apple(.sweet)")
+                args((Fruit.apple(.sweet),              true),  expect: "Fruit.apple(Taste.sweet)")
+                
+                // nested two
+                args((Fruit.apple(.sour(.high)),        false), expect: ".apple(.sour(.high))")
+                args((Fruit.apple(.sour(.high)),        true),  expect: "Fruit.apple(Taste.sour(Level.high))")
 
-            // TODO: wait for support `tuple`
-            // ref: https://github.com/YusukeHosonuma/SwiftPrettyPrint/issues/34
-            //
-            // fruit = .orange(taste: .sour)
-            // XCTAssertEqual(pretty.string(fruit, debug: false),
-            //                #".orange(taste: .sour)"#)
+                // nested two with label
+                args((Fruit.orange(taste: .sour(.low)), false), expect: ".orange(taste: .sour(.low))")
+                args((Fruit.orange(taste: .sour(.low)), true),  expect: "Fruit.orange(taste: Taste.sour(Level.low))")
+            }
         }
     }
 

--- a/Tests/Core/PrettyTests.swift
+++ b/Tests/Core/PrettyTests.swift
@@ -190,8 +190,8 @@ class PrettyTests: XCTestCase {
 
             assert(to: pretty.string) {
                 // has one
-                args((Fruit.apple("りんご"),      false), expect: #".apple("りんご")"#)
-                args((Fruit.apple("りんご"),      true),  expect: #"Fruit.apple("りんご")"#)
+                args((Fruit.apple("りんご"), false), expect: #".apple("りんご")"#)
+                args((Fruit.apple("りんご"), true),  expect: #"Fruit.apple("りんご")"#)
 
                 // has many (representation as a tuple)
                 args((Fruit.orange("みかん", 42), false), expect: #".orange("みかん", 42)"#)
@@ -222,12 +222,12 @@ class PrettyTests: XCTestCase {
 
             assert(to: pretty.string) {
                 // nested one
-                args((Fruit.apple(.sweet),              false), expect: ".apple(.sweet)")
-                args((Fruit.apple(.sweet),              true),  expect: "Fruit.apple(Taste.sweet)")
+                args((Fruit.apple(.sweet), false), expect: ".apple(.sweet)")
+                args((Fruit.apple(.sweet), true),  expect: "Fruit.apple(Taste.sweet)")
                 
                 // nested two
-                args((Fruit.apple(.sour(.high)),        false), expect: ".apple(.sour(.high))")
-                args((Fruit.apple(.sour(.high)),        true),  expect: "Fruit.apple(Taste.sour(Level.high))")
+                args((Fruit.apple(.sour(.high)), false), expect: ".apple(.sour(.high))")
+                args((Fruit.apple(.sour(.high)), true),  expect: "Fruit.apple(Taste.sour(Level.high))")
 
                 // nested two with label
                 args((Fruit.orange(taste: .sour(.low)), false), expect: ".orange(taste: .sour(.low))")

--- a/Tests/Extension/String+extensionTests.swift
+++ b/Tests/Extension/String+extensionTests.swift
@@ -39,4 +39,19 @@ class String_extensionTests: XCTestCase {
                                     """)
         }
     }
+    
+    func testRemoveEnclosedParenthese() {
+        assert(to: String.removeEnclosedParenthese) {
+            // removed
+            args("()",    expect: "")
+            args("(x)",   expect: "x")
+            args("((x))", expect: "(x)")
+
+            // not removed
+            args("(",  expect: "(")
+            args(")",  expect: ")")
+            args("(x", expect: "(x")
+            args("x)", expect: "x)")
+        }
+    }
 }

--- a/Tests/Extension/String+extensionTests.swift
+++ b/Tests/Extension/String+extensionTests.swift
@@ -40,8 +40,8 @@ class String_extensionTests: XCTestCase {
         }
     }
     
-    func testRemoveEnclosedParenthese() {
-        assert(to: String.removeEnclosedParenthese) {
+    func testRemoveEnclosedParentheses() {
+        assert(to: String.removeEnclosedParentheses) {
             // removed
             args("()",    expect: "")
             args("(x)",   expect: "x")


### PR DESCRIPTION
## TODO
- [x] change destination to `master`