### PR TITLE
implement new line for brace

### DIFF
--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -60,8 +60,10 @@ class MultilineFormatter: PrettyFormatter {
     ///
     /// goes to
     ///
-    /// owner: Owner(name: "Nanachi",
-    ///              age: 4))
+    /// owner: Owner(
+    ///            name: "Nanachi",
+    ///            age: 4)
+    ///        )
     ///
     func objectString(
         typeName: String, fields: [(String, String)]

--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -66,18 +66,20 @@ class MultilineFormatter: PrettyFormatter {
     func objectString(
         typeName: String, fields: [(String, String)]
     ) -> String {
-        let prefix = "\(typeName)("
         let body: String
-
         if fields.count == 1, let field = fields.first {
             body = "\(field.0): \(field.1)"
         } else {
             body = fields
                 .map { label, value in "\(label): \(value.indentTail(size: "\(label): ".count))" }
                 .joined(separator: ",\n")
-                .indentTail(size: prefix.count)
+                .indentTail(size: "\(typeName)".count)
         }
 
-        return prefix + body + ")"
+        return """
+        \(typeName)(
+        \(body)
+        )
+        """
     }
 }

--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -67,7 +67,7 @@ class MultilineFormatter: PrettyFormatter {
         typeName: String, fields: [(String, String)]
     ) -> String {
         if fields.count == 1, let field = fields.first {
-            return "\(typeName)(\(field.0): \(field.1))"
+            return "\(typeName)(" + "\(field.0): \(field.1)" + ")"
         } else {
             let body = fields
                 .map { label, value in "\(label): \(value.indentTail(size: "\(label): ".count))" }

--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -66,20 +66,19 @@ class MultilineFormatter: PrettyFormatter {
     func objectString(
         typeName: String, fields: [(String, String)]
     ) -> String {
-        let body: String
         if fields.count == 1, let field = fields.first {
-            body = "\(field.0): \(field.1)"
+            return "\(typeName)(\(field.0): \(field.1))"
         } else {
-            body = fields
+            let body = fields
                 .map { label, value in "\(label): \(value.indentTail(size: "\(label): ".count))" }
                 .joined(separator: ",\n")
-                .indentTail(size: "\(typeName)".count)
-        }
+                .indent(size: "\(typeName)".count)
 
-        return """
-        \(typeName)(
-        \(body)
-        )
-        """
+            return """
+            \(typeName)(
+            \(body)
+            )
+            """
+        }
     }
 }

--- a/Sources/Core/Formatter/MultilineFormatter.swift
+++ b/Sources/Core/Formatter/MultilineFormatter.swift
@@ -72,7 +72,7 @@ class MultilineFormatter: PrettyFormatter {
             let body = fields
                 .map { label, value in "\(label): \(value.indentTail(size: "\(label): ".count))" }
                 .joined(separator: ",\n")
-                .indent(size: "\(typeName)".count)
+                .indent(size: option.indent)
 
             return """
             \(typeName)(

--- a/Tests/SwiftPrettyPrintTests/Core/Formatter/MultilineFormatterTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Core/Formatter/MultilineFormatterTests.swift
@@ -108,8 +108,8 @@ class MultilineFormatterTests: XCTestCase {
             ("name", #""pochi""#),
             ("owner", """
             Owner(
-                 name: "Nanachi",
-                 age: 4
+                name: "Nanachi",
+                age: 4
             )
             """),
         ]
@@ -117,11 +117,11 @@ class MultilineFormatterTests: XCTestCase {
         let expected =
         """
         Dog(
-           name: "pochi",
-           owner: Owner(
-                       name: "Nanachi",
-                       age: 4
-                  )
+          name: "pochi",
+          owner: Owner(
+                     name: "Nanachi",
+                     age: 4
+                 )
         )
         """
 

--- a/Tests/SwiftPrettyPrintTests/Core/Formatter/MultilineFormatterTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Core/Formatter/MultilineFormatterTests.swift
@@ -104,7 +104,32 @@ class MultilineFormatterTests: XCTestCase {
     }
 
     func testObjectString() {
-        let fields: [(String, String)] = [
+        var fields: [(String, String)] = [
+            ("name", #""pochi""#),
+            ("owner", """
+            Owner(
+              name: "Nanachi",
+              age: 4
+            )
+            """),
+        ]
+
+        var expected =
+        """
+        Dog(
+          name: "pochi",
+          owner: Owner(
+                   name: "Nanachi",
+                   age: 4
+                 )
+        )
+        """
+
+        formatter = MultilineFormatter(option: option(indent: 2))
+        assertEqualLines(formatter.objectString(typeName: "Dog", fields: fields), expected)
+
+
+        fields = [
             ("name", #""pochi""#),
             ("owner", """
             Owner(
@@ -114,18 +139,18 @@ class MultilineFormatterTests: XCTestCase {
             """),
         ]
 
-        let expected =
+        expected =
         """
         Dog(
-          name: "pochi",
-          owner: Owner(
-                     name: "Nanachi",
-                     age: 4
-                 )
+            name: "pochi",
+            owner: Owner(
+                       name: "Nanachi",
+                       age: 4
+                   )
         )
         """
 
-        formatter = MultilineFormatter(option: option(indent: 2))
+        formatter = MultilineFormatter(option: option(indent: 4))
         assertEqualLines(formatter.objectString(typeName: "Dog", fields: fields), expected)
     }
     

--- a/Tests/SwiftPrettyPrintTests/Core/Formatter/MultilineFormatterTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Core/Formatter/MultilineFormatterTests.swift
@@ -107,18 +107,26 @@ class MultilineFormatterTests: XCTestCase {
         let fields: [(String, String)] = [
             ("name", #""pochi""#),
             ("owner", """
-            Owner(name: "Nanachi",
-                  age: 4)
+            Owner(
+                 name: "Nanachi",
+                 age: 4
+            )
             """),
         ]
 
+        let expected =
+        """
+        Dog(
+           name: "pochi",
+           owner: Owner(
+                       name: "Nanachi",
+                       age: 4
+                  )
+        )
+        """
+
         formatter = MultilineFormatter(option: option(indent: 2))
-        assertEqualLines(formatter.objectString(typeName: "Dog", fields: fields),
-                         """
-                         Dog(name: "pochi",
-                             owner: Owner(name: "Nanachi",
-                                          age: 4))
-                         """)
+        assertEqualLines(formatter.objectString(typeName: "Dog", fields: fields), expected)
     }
     
     // MARK: - Helper

--- a/Tests/SwiftPrettyPrintTests/Public/DebugTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/DebugTests.swift
@@ -96,22 +96,26 @@ class DebugTests: XCTestCase {
         Debug.prettyPrint(dog, to: &result)
         assertEqualLines(result,
                          """
-                         Dog(id: "pochi",
-                             name: "ポチ",
-                             nickname: nil,
-                             age: 3,
-                             homepage: https://www.google.com/)
+                         Dog(
+                            id: "pochi",
+                            name: "ポチ",
+                            nickname: nil,
+                            age: 3,
+                            homepage: https://www.google.com/
+                         )
                          """ + "\n")
 
         result = ""
         Debug.debugPrettyPrint(dog, to: &result)
         assertEqualLines(result,
                          """
-                         Dog(id: DogId(rawValue: "pochi"),
-                             name: Optional("ポチ"),
-                             nickname: nil,
-                             age: 3,
-                             homepage: Optional(https://www.google.com/))
+                         Dog(
+                            id: DogId(rawValue: "pochi"),
+                            name: Optional("ポチ"),
+                            nickname: nil,
+                            age: 3,
+                            homepage: Optional(https://www.google.com/)
+                         )
                          """ + "\n")
 
         result = ""
@@ -119,16 +123,20 @@ class DebugTests: XCTestCase {
         assertEqualLines(result,
                          """
                          [
-                             Dog(id: "pochi",
-                                 name: "ポチ",
-                                 nickname: nil,
-                                 age: 3,
-                                 homepage: https://www.google.com/),
-                             Dog(id: "pochi",
-                                 name: "ポチ",
-                                 nickname: nil,
-                                 age: 3,
-                                 homepage: https://www.google.com/)
+                             Dog(
+                                id: "pochi",
+                                name: "ポチ",
+                                nickname: nil,
+                                age: 3,
+                                homepage: https://www.google.com/
+                             ),
+                             Dog(
+                                id: "pochi",
+                                name: "ポチ",
+                                nickname: nil,
+                                age: 3,
+                                homepage: https://www.google.com/
+                             )
                          ]
                          """ + "\n")
 
@@ -137,16 +145,20 @@ class DebugTests: XCTestCase {
         assertEqualLines(result,
                          """
                          [
-                             Dog(id: DogId(rawValue: "pochi"),
-                                 name: Optional("ポチ"),
-                                 nickname: nil,
-                                 age: 3,
-                                 homepage: Optional(https://www.google.com/)),
-                             Dog(id: DogId(rawValue: "pochi"),
-                                 name: Optional("ポチ"),
-                                 nickname: nil,
-                                 age: 3,
-                                 homepage: Optional(https://www.google.com/))
+                             Dog(
+                                id: DogId(rawValue: "pochi"),
+                                name: Optional("ポチ"),
+                                nickname: nil,
+                                age: 3,
+                                homepage: Optional(https://www.google.com/)
+                             ),
+                             Dog(
+                                id: DogId(rawValue: "pochi"),
+                                name: Optional("ポチ"),
+                                nickname: nil,
+                                age: 3,
+                                homepage: Optional(https://www.google.com/)
+                             )
                          ]
                          """ + "\n")
 
@@ -160,16 +172,20 @@ class DebugTests: XCTestCase {
         assertEqualLines(result,
                          """
                          [
-                             "dog-1": Dog(id: "pochi",
-                                          name: "ポチ",
-                                          nickname: nil,
-                                          age: 3,
-                                          homepage: https://www.google.com/),
-                             "dog-2": Dog(id: "pochi",
-                                          name: "ポチ",
-                                          nickname: nil,
-                                          age: 3,
-                                          homepage: https://www.google.com/)
+                             "dog-1": Dog(
+                                         id: "pochi",
+                                         name: "ポチ",
+                                         nickname: nil,
+                                         age: 3,
+                                         homepage: https://www.google.com/
+                                      ),
+                             "dog-2": Dog(
+                                         id: "pochi",
+                                         name: "ポチ",
+                                         nickname: nil,
+                                         age: 3,
+                                         homepage: https://www.google.com/
+                                      )
                          ]
                          """ + "\n")
 
@@ -178,16 +194,20 @@ class DebugTests: XCTestCase {
         assertEqualLines(result,
                          """
                          [
-                             "dog-1": Dog(id: DogId(rawValue: "pochi"),
-                                          name: Optional("ポチ"),
-                                          nickname: nil,
-                                          age: 3,
-                                          homepage: Optional(https://www.google.com/)),
-                             "dog-2": Dog(id: DogId(rawValue: "pochi"),
-                                          name: Optional("ポチ"),
-                                          nickname: nil,
-                                          age: 3,
-                                          homepage: Optional(https://www.google.com/))
+                             "dog-1": Dog(
+                                         id: DogId(rawValue: "pochi"),
+                                         name: Optional("ポチ"),
+                                         nickname: nil,
+                                         age: 3,
+                                         homepage: Optional(https://www.google.com/)
+                                      ),
+                             "dog-2": Dog(
+                                         id: DogId(rawValue: "pochi"),
+                                         name: Optional("ポチ"),
+                                         nickname: nil,
+                                         age: 3,
+                                         homepage: Optional(https://www.google.com/)
+                                      )
                          ]
                          """ + "\n")
     }

--- a/Tests/SwiftPrettyPrintTests/Public/DebugTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/DebugTests.swift
@@ -97,11 +97,11 @@ class DebugTests: XCTestCase {
         assertEqualLines(result,
                          """
                          Dog(
-                            id: "pochi",
-                            name: "ポチ",
-                            nickname: nil,
-                            age: 3,
-                            homepage: https://www.google.com/
+                             id: "pochi",
+                             name: "ポチ",
+                             nickname: nil,
+                             age: 3,
+                             homepage: https://www.google.com/
                          )
                          """ + "\n")
 
@@ -110,11 +110,11 @@ class DebugTests: XCTestCase {
         assertEqualLines(result,
                          """
                          Dog(
-                            id: DogId(rawValue: "pochi"),
-                            name: Optional("ポチ"),
-                            nickname: nil,
-                            age: 3,
-                            homepage: Optional(https://www.google.com/)
+                             id: DogId(rawValue: "pochi"),
+                             name: Optional("ポチ"),
+                             nickname: nil,
+                             age: 3,
+                             homepage: Optional(https://www.google.com/)
                          )
                          """ + "\n")
 
@@ -124,18 +124,18 @@ class DebugTests: XCTestCase {
                          """
                          [
                              Dog(
-                                id: "pochi",
-                                name: "ポチ",
-                                nickname: nil,
-                                age: 3,
-                                homepage: https://www.google.com/
+                                 id: "pochi",
+                                 name: "ポチ",
+                                 nickname: nil,
+                                 age: 3,
+                                 homepage: https://www.google.com/
                              ),
                              Dog(
-                                id: "pochi",
-                                name: "ポチ",
-                                nickname: nil,
-                                age: 3,
-                                homepage: https://www.google.com/
+                                 id: "pochi",
+                                 name: "ポチ",
+                                 nickname: nil,
+                                 age: 3,
+                                 homepage: https://www.google.com/
                              )
                          ]
                          """ + "\n")
@@ -146,18 +146,18 @@ class DebugTests: XCTestCase {
                          """
                          [
                              Dog(
-                                id: DogId(rawValue: "pochi"),
-                                name: Optional("ポチ"),
-                                nickname: nil,
-                                age: 3,
-                                homepage: Optional(https://www.google.com/)
+                                 id: DogId(rawValue: "pochi"),
+                                 name: Optional("ポチ"),
+                                 nickname: nil,
+                                 age: 3,
+                                 homepage: Optional(https://www.google.com/)
                              ),
                              Dog(
-                                id: DogId(rawValue: "pochi"),
-                                name: Optional("ポチ"),
-                                nickname: nil,
-                                age: 3,
-                                homepage: Optional(https://www.google.com/)
+                                 id: DogId(rawValue: "pochi"),
+                                 name: Optional("ポチ"),
+                                 nickname: nil,
+                                 age: 3,
+                                 homepage: Optional(https://www.google.com/)
                              )
                          ]
                          """ + "\n")
@@ -173,18 +173,18 @@ class DebugTests: XCTestCase {
                          """
                          [
                              "dog-1": Dog(
-                                         id: "pochi",
-                                         name: "ポチ",
-                                         nickname: nil,
-                                         age: 3,
-                                         homepage: https://www.google.com/
+                                          id: "pochi",
+                                          name: "ポチ",
+                                          nickname: nil,
+                                          age: 3,
+                                          homepage: https://www.google.com/
                                       ),
                              "dog-2": Dog(
-                                         id: "pochi",
-                                         name: "ポチ",
-                                         nickname: nil,
-                                         age: 3,
-                                         homepage: https://www.google.com/
+                                          id: "pochi",
+                                          name: "ポチ",
+                                          nickname: nil,
+                                          age: 3,
+                                          homepage: https://www.google.com/
                                       )
                          ]
                          """ + "\n")
@@ -195,18 +195,18 @@ class DebugTests: XCTestCase {
                          """
                          [
                              "dog-1": Dog(
-                                         id: DogId(rawValue: "pochi"),
-                                         name: Optional("ポチ"),
-                                         nickname: nil,
-                                         age: 3,
-                                         homepage: Optional(https://www.google.com/)
+                                          id: DogId(rawValue: "pochi"),
+                                          name: Optional("ポチ"),
+                                          nickname: nil,
+                                          age: 3,
+                                          homepage: Optional(https://www.google.com/)
                                       ),
                              "dog-2": Dog(
-                                         id: DogId(rawValue: "pochi"),
-                                         name: Optional("ポチ"),
-                                         nickname: nil,
-                                         age: 3,
-                                         homepage: Optional(https://www.google.com/)
+                                          id: DogId(rawValue: "pochi"),
+                                          name: Optional("ポチ"),
+                                          nickname: nil,
+                                          age: 3,
+                                          homepage: Optional(https://www.google.com/)
                                       )
                          ]
                          """ + "\n")


### PR DESCRIPTION
resolved #49

## As is
### At first glance, it is difficult to understand the hierarchy
If the following is implimented,
```
struct A {
  let b: B
  let string: String
}

struct B {
  let string: String
  let int: Int
}

let target = A(b: B(string: "hoge", int: 0), string: "foo")
Debug.pp >>> target
```
the result will be the following.
```
A(b: B(string: "hoge",
       int: 0),
  string: "foo")
```


## To be
### Using indent and new-line make the hierarchy easier to understand.

the result will be the following.
```
A(
 b: B(
     string: "hoge",
     int: 0
    ),
 string: "foo"
)
```
