### PR TITLE
rename API `Debug` to `Pretty`

### DIFF
--- a/Example/SwiftPrettyPrintExample/Source/AppDelegate.swift
+++ b/Example/SwiftPrettyPrintExample/Source/AppDelegate.swift
@@ -6,7 +6,6 @@
 // Copyright (c) 2020 Yusuke Hosonuma.
 //
 
-import SwiftPrettyPrint
 import UIKit
 
 @UIApplicationMain

--- a/Example/SwiftPrettyPrintExample/Source/Debug.swift
+++ b/Example/SwiftPrettyPrintExample/Source/Debug.swift
@@ -12,5 +12,5 @@
 
 #if canImport(SwiftPrettyPrint)
     import SwiftPrettyPrint
-    typealias Debug = SwiftPrettyPrint.Debug
+    typealias Debug = SwiftPrettyPrint.Pretty
 #endif

--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ This output is enough information for debug, but **not human-readable**.
 With SwiftPrittyPrint it looks like this:
 
 ```swift
-Debug.print(value)
+Pretty.print(value)
 // Struct(array: [1, 2, nil], dictionary: ["one": 1, "two": 2], tuple: (1, string: "string"), enum: .foo(42), id: 7)
 
-Debug.printDebug(value)
+Pretty.printDebug(value)
 // Struct(array: [Optional(1), Optional(2), nil], dictionary: ["one": 1, "two": 2], tuple: (1, string: "string"), enum: Enum.foo(42), id: ID(id: 7))
 
-Debug.prettyPrint(value)
+Pretty.prettyPrint(value)
 // Struct(
 //     array: [
 //         1,
@@ -111,7 +111,7 @@ Debug.prettyPrint(value)
 //     id: 7
 // )
 
-Debug.prettyPrintDebug(value)
+Pretty.prettyPrintDebug(value)
 // Struct(
 //     array: [
 //         Optional(1),
@@ -134,7 +134,7 @@ Debug.prettyPrintDebug(value)
 Of cource, it can also be used with **LLDB**.
 
 ```text
-(lldb) e Debug.prettyPrint(value)
+(lldb) e Pretty.prettyPrint(value)
 Struct(
     array: [
         1,
@@ -180,10 +180,10 @@ pp >>> ["Hello", "World"]
 
 | Operator syntax | Equatable to                 |
 |-----------------|------------------------------|
-| `p >>> 42`      | `Debug.print(42)`            |
-| `pp >>> 42`     | `Debug.prettyPrint(42)`      |
-| `pd >>> 42`     | `Debug.printDebug(42)`       |
-| `ppd >>> 42`    | `Debug.prettyPrintDebug(42)` |
+| `p >>> 42`      | `Pretty.print(42)`            |
+| `pp >>> 42`     | `Pretty.prettyPrint(42)`      |
+| `pd >>> 42`     | `Pretty.printDebug(42)`       |
+| `ppd >>> 42`    | `Pretty.prettyPrintDebug(42)` |
 
 ## Format options
 
@@ -195,10 +195,10 @@ You can specify indent size in pretty-print as like following:
 
 ```swift
 // Global option
-Debug.sharedOption = Debug.Option(prefix: nil, indentSize: 4)
+Pretty.sharedOption = Pretty.Option(prefix: nil, indentSize: 4)
 
 // Use `sharedOption`
-Debug.prettyPrint(["Hello", "World"])
+Pretty.prettyPrint(["Hello", "World"])
 // =>
 // [
 //     "Hello",
@@ -206,7 +206,7 @@ Debug.prettyPrint(["Hello", "World"])
 // ]
 
 // Use option that is passed by argument
-Debug.prettyPrint(["Hello", "World"], option: Debug.Option(prefix: nil, indentSize: 2))
+Pretty.prettyPrint(["Hello", "World"], option: Pretty.Option(prefix: nil, indentSize: 2))
 // =>
 // [
 //   "Hello",
@@ -219,14 +219,14 @@ Debug.prettyPrint(["Hello", "World"], option: Debug.Option(prefix: nil, indentSi
 You can specify global prefix and label (e.g. variable name) as like following:
 
 ```swift
-Debug.sharedOption = Debug.Option(prefix: "[DEBUG]", indentSize: 4)
+Pretty.sharedOption = Pretty.Option(prefix: "[DEBUG]", indentSize: 4)
 
 let array = ["Hello", "World"]
 
-Debug.print(label: "array", array)
+Pretty.print(label: "array", array)
 // => [DEBUG] array: ["Hello", "World"]
 
-Debug.prettyPrint(label: "array", array)
+Pretty.prettyPrint(label: "array", array)
 // =>
 // [DEBUG] array:
 // [
@@ -234,7 +234,7 @@ Debug.prettyPrint(label: "array", array)
 //     "World"
 // ]
 
-Debug.p("array") >>> array
+Pretty.p("array") >>> array
 // => [DEBUG] array: ["Hello", "World"]
 ```
 
@@ -268,23 +268,26 @@ or add from Xcode 10+.
 
 You don't want to write an `import` statement when debagging.
 
-We recommend to create `Debug.swift` and write as following:
+We recommend to create `Debug.swift` and declaration any type as `typealias` like following:
 
 ```swift
+// Debug.swifts
 #if canImport(SwiftPrettyPrint)
     import SwiftPrettyPrint
-    typealias Debug = SwiftPrettyPrint.Debug // You can use short alias such as `D` too.
+    typealias Debug = SwiftPrettyPrint.Pretty // You can use short alias such as `D` too.
 #endif
 ```
 
-or
+This can be not need to write `import` in each sources.
 
 ```swift
-#if canImport(SwiftPrettyPrint)
-    @_exported import SwiftPrettyPrint // Note: `@_exported` is not official
-#endif
+// AnySource.swift
+Debug.print(42)
+Debug.prettyPrint(label: "array", array)
 ```
-This can be not need to write `import` in each sources.
+
+Note:
+This is can't use to the operator-based API such as `p >>>`. (This is a Swift language's limitation)
 
 ## Xcode Code Snippets
 

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -1,5 +1,5 @@
 //
-// Pretty.swift
+// PrettyDescriber.swift
 // SwiftPrettyPrint
 //
 // Created by Yusuke Hosonuma on 2020/02/27.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct Pretty {
+struct PrettyDescriber {
     var formatter: PrettyFormatter
     var timeZone: TimeZone = .current
 

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -113,7 +113,7 @@ struct PrettyDescriber {
             guard
                 let key = root.children.first?.value,
                 let value = root.children.dropFirst().first?.value else {
-                throw PrettyError.failedExtractKeyValue(dictionary: dictionary)
+                throw PrettyDescriberError.failedExtractKeyValue(dictionary: dictionary)
             }
 
             return (key, value)
@@ -197,7 +197,7 @@ struct PrettyDescriber {
             }
         } else {
             guard let index = "\(target)".firstIndex(of: "(") else {
-                throw PrettyError.unknownError(target: target)
+                throw PrettyDescriberError.unknownError(target: target)
             }
 
             let valueName = "\(target)"[..<index]
@@ -210,7 +210,7 @@ struct PrettyDescriber {
             }
 
             guard let childValue = mirror.children.first?.value else {
-                throw PrettyError.unknownError(target: target)
+                throw PrettyDescriberError.unknownError(target: target)
             }
 
             let body = string(childValue, debug: debug)

--- a/Sources/Core/PrettyDescriberError.swift
+++ b/Sources/Core/PrettyDescriberError.swift
@@ -1,5 +1,5 @@
 //
-//  PrettyError.swift
+//  PrettyDescriberError.swift
 //  SwiftPrettyPrint
 //
 //  Created by Yusuke Hosonuma on 2020/02/25.
@@ -7,13 +7,13 @@
 
 import Foundation
 
-enum PrettyError: Error {
+enum PrettyDescriberError: Error {
     case notSupported(target: Any)
     case failedExtractKeyValue(dictionary: Any)
     case unknownError(target: Any)
 }
 
-extension PrettyError: LocalizedError {
+extension PrettyDescriberError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case let .notSupported(target: target):
@@ -34,7 +34,7 @@ extension PrettyError: LocalizedError {
     }
 }
 
-extension PrettyError: CustomStringConvertible {
+extension PrettyDescriberError: CustomStringConvertible {
     var description: String {
         switch self {
         case .notSupported:

--- a/Sources/Public/Debug.swift
+++ b/Sources/Public/Debug.swift
@@ -155,7 +155,7 @@ extension Debug {
     ) -> String {
         prefixLabel(option.prefix, label) +
             targets.map {
-                Pretty(formatter: SinglelineFormatter()).string($0, debug: false)
+                PrettyDescriber(formatter: SinglelineFormatter()).string($0, debug: false)
             }.joined(separator: separator)
     }
 
@@ -167,7 +167,7 @@ extension Debug {
     ) -> String {
         prefixLabelPretty(option.prefix, label) +
             targets.map {
-                Pretty(formatter: MultilineFormatter(indentSize: option.indentSize)).string($0, debug: false)
+                PrettyDescriber(formatter: MultilineFormatter(indentSize: option.indentSize)).string($0, debug: false)
             }.joined(separator: separator)
     }
 
@@ -179,7 +179,7 @@ extension Debug {
     ) -> String {
         prefixLabel(option.prefix, label) +
             targets.map {
-                Pretty(formatter: SinglelineFormatter()).string($0, debug: true)
+                PrettyDescriber(formatter: SinglelineFormatter()).string($0, debug: true)
             }.joined(separator: separator)
     }
 
@@ -191,7 +191,7 @@ extension Debug {
     ) -> String {
         prefixLabelPretty(option.prefix, label) +
             targets.map {
-                Pretty(formatter: MultilineFormatter(indentSize: option.indentSize)).string($0, debug: true)
+                PrettyDescriber(formatter: MultilineFormatter(indentSize: option.indentSize)).string($0, debug: true)
             }.joined(separator: separator)
     }
 }

--- a/Sources/Public/Operator.swift
+++ b/Sources/Public/Operator.swift
@@ -18,10 +18,10 @@
 // string.hasPrefix("Hello")
 //
 // // when use `print()` - needs enclose in parenthese
-// Debug.print(string.hasPrefix("Hello"))
+// Pretty.print(string.hasPrefix("Hello"))
 //
 // // when use `p` - not needs enclose in parenthese
-// Debug.p >>> string.hasPrefix("Hello")
+// Pretty.p >>> string.hasPrefix("Hello")
 // ```
 //
 // Also the operator `>>>` has lower precedence than all standard operators in Swift,
@@ -58,38 +58,38 @@ precedencegroup PrintPrecedence {
 
 infix operator >>>: PrintPrecedence
 
-// MARK: `Debug.p >>>`
+// MARK: `p >>>`
 
 public func >>> (_: (String) -> P, target: Any) {
-    Debug.print(target)
+    Pretty.print(target)
 }
 
 public func >>> (_: (String) -> PD, target: Any) {
-    Debug.printDebug(target)
+    Pretty.printDebug(target)
 }
 
 public func >>> (_: (String) -> PP, target: Any) {
-    Debug.prettyPrint(target)
+    Pretty.prettyPrint(target)
 }
 
 public func >>> (_: (String) -> PPD, target: Any) {
-    Debug.prettyPrintDebug(target)
+    Pretty.prettyPrintDebug(target)
 }
 
-// MARK: `Debug.p("xxx") >>>`
+// MARK: `p("xxx") >>>`
 
 public func >>> (receiver: P, target: Any) {
-    Debug.print(label: receiver.label, target)
+    Pretty.print(label: receiver.label, target)
 }
 
 public func >>> (receiver: PD, target: Any) {
-    Debug.printDebug(label: receiver.label, target)
+    Pretty.printDebug(label: receiver.label, target)
 }
 
 public func >>> (receiver: PP, target: Any) {
-    Debug.prettyPrint(label: receiver.label, target)
+    Pretty.prettyPrint(label: receiver.label, target)
 }
 
 public func >>> (receiver: PPD, target: Any) {
-    Debug.prettyPrintDebug(label: receiver.label, target)
+    Pretty.prettyPrintDebug(label: receiver.label, target)
 }

--- a/Sources/Public/Option.swift
+++ b/Sources/Public/Option.swift
@@ -6,7 +6,7 @@
 // Copyright (c) 2020 Yusuke Hosonuma.
 //
 
-extension Debug {
+extension Pretty {
     public struct Option {
         public var prefix: String?
         public var indentSize: Int

--- a/Sources/Public/Pretty.swift
+++ b/Sources/Public/Pretty.swift
@@ -1,35 +1,35 @@
 //
-// Debug.swift
+// Pretty.swift
 // SwiftPrettyPrint
 //
 // Created by Yusuke Hosonuma on 2020/02/27.
 // Copyright (c) 2020 Yusuke Hosonuma.
 //
 
-public class Debug {
+public class Pretty {
     /// Default format option
     public static let defaultOption = Option(prefix: nil, indentSize: 4)
 
     /// Global format option
-    public static var sharedOption: Option = Debug.defaultOption
+    public static var sharedOption: Option = Pretty.defaultOption
 
     private init() {}
 }
 
 // MARK: Standard API
 
-extension Debug {
+extension Pretty {
     /// Output `targets` to console.
     /// - Parameters:
     ///   - label: label
     ///   - targets: targets
     ///   - separator: A string to print between each item.
-    ///   - option: option (default: `Debug.sharedOption`)
+    ///   - option: option (default: `Pretty.sharedOption`)
     public static func print(
         label: String? = nil,
         _ targets: Any...,
         separator: String = " ",
-        option: Option = Debug.sharedOption
+        option: Option = Pretty.sharedOption
     ) {
         Swift.print(_print(label: label, targets, separator: separator, option: option))
     }
@@ -39,13 +39,13 @@ extension Debug {
     ///   - label: label
     ///   - target: targets
     ///   - separator: A string to print between each item.
-    ///   - option: option (default: `Debug.sharedOption`)
+    ///   - option: option (default: `Pretty.sharedOption`)
     ///   - output: output
     public static func print<Target: TextOutputStream>(
         label: String? = nil,
         _ targets: Any...,
         separator: String = " ",
-        option: Option = Debug.sharedOption,
+        option: Option = Pretty.sharedOption,
         to output: inout Target
     ) {
         Swift.print(_print(label: label, targets, separator: separator, option: option), to: &output)
@@ -56,12 +56,12 @@ extension Debug {
     ///   - label: label
     ///   - targets: targets
     ///   - separator: A string to print between each item.
-    ///   - option: option (default: `Debug.sharedOption`)
+    ///   - option: option (default: `Pretty.sharedOption`)
     public static func prettyPrint(
         label: String? = nil,
         _ targets: Any...,
         separator: String = "\n",
-        option: Option = Debug.sharedOption
+        option: Option = Pretty.sharedOption
     ) {
         Swift.print(_prettyPrint(label: label, targets, separator: separator, option: option))
     }
@@ -71,13 +71,13 @@ extension Debug {
     ///   - label: label
     ///   - targets: targets
     ///   - separator: A string to print between each item.
-    ///   - option: option (default: `Debug.sharedOption`)
+    ///   - option: option (default: `Pretty.sharedOption`)
     ///   - output: output
     public static func prettyPrint<Target: TextOutputStream>(
         label: String? = nil,
         _ targets: Any...,
         separator: String = "\n",
-        option: Option = Debug.sharedOption,
+        option: Option = Pretty.sharedOption,
         to output: inout Target
     ) {
         Swift.print(_prettyPrint(label: label, targets, separator: separator, option: option), to: &output)
@@ -88,12 +88,12 @@ extension Debug {
     ///   - label: label
     ///   - targets: targets
     ///   - separator: A string to print between each item.
-    ///   - option: option (default: `Debug.sharedOption`)
+    ///   - option: option (default: `Pretty.sharedOption`)
     public static func printDebug(
         label: String? = nil,
         _ targets: Any...,
         separator: String = " ",
-        option: Option = Debug.sharedOption
+        option: Option = Pretty.sharedOption
     ) {
         Swift.print(_printDebug(label: label, targets, separator: separator, option: option))
     }
@@ -103,13 +103,13 @@ extension Debug {
     ///   - label: label
     ///   - targets: targets
     ///   - separator: A string to print between each item.
-    ///   - option: option (default: `Debug.sharedOption`)
+    ///   - option: option (default: `Pretty.sharedOption`)
     ///   - output: output
     public static func printDebug<Target: TextOutputStream>(
         label: String? = nil,
         _ targets: Any...,
         separator: String = " ",
-        option: Option = Debug.sharedOption,
+        option: Option = Pretty.sharedOption,
         to output: inout Target
     ) {
         Swift.print(_printDebug(label: label, targets, separator: separator, option: option), to: &output)
@@ -119,12 +119,12 @@ extension Debug {
     /// - Parameters:
     ///   - targets: targets
     ///   - separator: A string to print between each item.
-    ///   - option: option (default: `Debug.sharedOption`)
+    ///   - option: option (default: `Pretty.sharedOption`)
     public static func prettyPrintDebug(
         label: String? = nil,
         _ targets: Any...,
         separator: String = "\n",
-        option: Option = Debug.sharedOption
+        option: Option = Pretty.sharedOption
     ) {
         Swift.print(_prettyPrintDebug(label: label, targets, separator: separator, option: option))
     }
@@ -133,13 +133,13 @@ extension Debug {
     /// - Parameters:
     ///   - targets: targets
     ///   - separator: A string to print between each item.
-    ///   - option: option (default: `Debug.sharedOption`)
+    ///   - option: option (default: `Pretty.sharedOption`)
     ///   - output: output
     public static func prettyPrintDebug<Target: TextOutputStream>(
         label: String? = nil,
         _ targets: Any...,
         separator: String = "\n",
-        option: Option = Debug.sharedOption,
+        option: Option = Pretty.sharedOption,
         to output: inout Target
     ) {
         Swift.print(_prettyPrintDebug(label: label, targets, separator: separator, option: option), to: &output)

--- a/SwiftPrettyPrint.xcodeproj/project.pbxproj
+++ b/SwiftPrettyPrint.xcodeproj/project.pbxproj
@@ -32,7 +32,7 @@
 		OBJ_119 /* PrettyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* PrettyFormatter.swift */; };
 		OBJ_120 /* SinglelineFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* SinglelineFormatter.swift */; };
 		OBJ_121 /* PrettyDescriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* PrettyDescriber.swift */; };
-		OBJ_122 /* PrettyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* PrettyError.swift */; };
+		OBJ_122 /* PrettyDescriberError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* PrettyDescriberError.swift */; };
 		OBJ_123 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Util.swift */; };
 		OBJ_124 /* String+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* String+extension.swift */; };
 		OBJ_125 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* Debug.swift */; };
@@ -98,7 +98,7 @@
 		OBJ_11 /* PrettyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyFormatter.swift; sourceTree = "<group>"; };
 		OBJ_12 /* SinglelineFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglelineFormatter.swift; sourceTree = "<group>"; };
 		OBJ_13 /* PrettyDescriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyDescriber.swift; sourceTree = "<group>"; };
-		OBJ_14 /* PrettyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyError.swift; sourceTree = "<group>"; };
+		OBJ_14 /* PrettyDescriberError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyDescriberError.swift; sourceTree = "<group>"; };
 		OBJ_15 /* Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
 		OBJ_17 /* String+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extension.swift"; sourceTree = "<group>"; };
 		OBJ_19 /* Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
@@ -391,7 +391,7 @@
 			children = (
 				OBJ_9 /* Formatter */,
 				OBJ_13 /* PrettyDescriber.swift */,
-				OBJ_14 /* PrettyError.swift */,
+				OBJ_14 /* PrettyDescriberError.swift */,
 				OBJ_15 /* Util.swift */,
 			);
 			path = Core;
@@ -569,7 +569,7 @@
 				OBJ_119 /* PrettyFormatter.swift in Sources */,
 				OBJ_120 /* SinglelineFormatter.swift in Sources */,
 				OBJ_121 /* PrettyDescriber.swift in Sources */,
-				OBJ_122 /* PrettyError.swift in Sources */,
+				OBJ_122 /* PrettyDescriberError.swift in Sources */,
 				OBJ_123 /* Util.swift in Sources */,
 				OBJ_124 /* String+extension.swift in Sources */,
 				OBJ_125 /* Debug.swift in Sources */,

--- a/SwiftPrettyPrint.xcodeproj/project.pbxproj
+++ b/SwiftPrettyPrint.xcodeproj/project.pbxproj
@@ -1,1512 +1,1080 @@
 // !$*UTF8*$!
 {
-   archiveVersion = "1";
-   objectVersion = "46";
-   objects = {
-      "Curry::Curry" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_78";
-         buildPhases = (
-            "OBJ_81",
-            "OBJ_83"
-         );
-         dependencies = (
-         );
-         name = "Curry";
-         productName = "Curry";
-         productReference = "Curry::Curry::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "Curry::Curry::Product" = {
-         isa = "PBXFileReference";
-         path = "Curry.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "Curry::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_85";
-         buildPhases = (
-            "OBJ_88"
-         );
-         dependencies = (
-         );
-         name = "CurryPackageDescription";
-         productName = "CurryPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "OBJ_1" = {
-         isa = "PBXProject";
-         attributes = {
-            LastSwiftMigration = "9999";
-            LastUpgradeCheck = "9999";
-         };
-         buildConfigurationList = "OBJ_2";
-         compatibilityVersion = "Xcode 3.2";
-         developmentRegion = "en";
-         hasScannedForEncodings = "0";
-         knownRegions = (
-            "en"
-         );
-         mainGroup = "OBJ_5";
-         productRefGroup = "OBJ_61";
-         projectDirPath = ".";
-         targets = (
-            "Curry::Curry",
-            "Curry::SwiftPMPackageDescription",
-            "SwiftParamTest::SwiftParamTest",
-            "SwiftParamTest::SwiftPMPackageDescription",
-            "SwiftPrettyPrint::SwiftPrettyPrint",
-            "SwiftPrettyPrint::SwiftPMPackageDescription",
-            "SwiftPrettyPrint::SwiftPrettyPrintPackageTests::ProductTarget",
-            "SwiftPrettyPrint::SwiftPrettyPrintTests"
-         );
-      };
-      "OBJ_10" = {
-         isa = "PBXFileReference";
-         path = "MultilineFormatter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_100" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_53";
-      };
-      "OBJ_101" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_55";
-      };
-      "OBJ_102" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_56";
-      };
-      "OBJ_103" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_57";
-      };
-      "OBJ_104" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_59";
-      };
-      "OBJ_105" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_60";
-      };
-      "OBJ_106" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_108" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_109",
-            "OBJ_110"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_109" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5.1"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_11" = {
-         isa = "PBXFileReference";
-         path = "PrettyFormatter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_110" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5.1"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Release";
-      };
-      "OBJ_111" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_112"
-         );
-      };
-      "OBJ_112" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_44";
-      };
-      "OBJ_114" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_115",
-            "OBJ_116"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_115" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftPrettyPrint.xcodeproj/SwiftPrettyPrint_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftPrettyPrint";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftPrettyPrint";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_116" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftPrettyPrint.xcodeproj/SwiftPrettyPrint_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftPrettyPrint";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftPrettyPrint";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_117" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_118",
-            "OBJ_119",
-            "OBJ_120",
-            "OBJ_121",
-            "OBJ_122",
-            "OBJ_123",
-            "OBJ_124",
-            "OBJ_125",
-            "OBJ_126",
-            "OBJ_127"
-         );
-      };
-      "OBJ_118" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_10";
-      };
-      "OBJ_119" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_11";
-      };
-      "OBJ_12" = {
-         isa = "PBXFileReference";
-         path = "SinglelineFormatter.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_120" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_12";
-      };
-      "OBJ_121" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_13";
-      };
-      "OBJ_122" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_14";
-      };
-      "OBJ_123" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_15";
-      };
-      "OBJ_124" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_17";
-      };
-      "OBJ_125" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_19";
-      };
-      "OBJ_126" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_20";
-      };
-      "OBJ_127" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_21";
-      };
-      "OBJ_128" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_13" = {
-         isa = "PBXFileReference";
-         path = "Pretty.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_130" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_131",
-            "OBJ_132"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_131" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5.1"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_132" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "5",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "5.1"
-            );
-            SWIFT_VERSION = "5.0";
-         };
-         name = "Release";
-      };
-      "OBJ_133" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_134"
-         );
-      };
-      "OBJ_134" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_6";
-      };
-      "OBJ_136" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_137",
-            "OBJ_138"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_137" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Debug";
-      };
-      "OBJ_138" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-         };
-         name = "Release";
-      };
-      "OBJ_139" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftPrettyPrint::SwiftPrettyPrintTests";
-      };
-      "OBJ_14" = {
-         isa = "PBXFileReference";
-         path = "PrettyError.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_141" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_142",
-            "OBJ_143"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_142" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftPrettyPrint.xcodeproj/SwiftPrettyPrintTests_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftPrettyPrintTests";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_143" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_MODULES = "YES";
-            EMBEDDED_CONTENT_CONTAINS_SWIFT = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftPrettyPrint.xcodeproj/SwiftPrettyPrintTests_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "@loader_path/../Frameworks",
-               "@loader_path/Frameworks"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftPrettyPrintTests";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_144" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_145",
-            "OBJ_146",
-            "OBJ_147",
-            "OBJ_148",
-            "OBJ_149",
-            "OBJ_150",
-            "OBJ_151",
-            "OBJ_152",
-            "OBJ_153",
-            "OBJ_154"
-         );
-      };
-      "OBJ_145" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_26";
-      };
-      "OBJ_146" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_27";
-      };
-      "OBJ_147" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_28";
-      };
-      "OBJ_148" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_29";
-      };
-      "OBJ_149" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_31";
-      };
-      "OBJ_15" = {
-         isa = "PBXFileReference";
-         path = "Util.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_150" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_33";
-      };
-      "OBJ_151" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_34";
-      };
-      "OBJ_152" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_36";
-      };
-      "OBJ_153" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_37";
-      };
-      "OBJ_154" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_38";
-      };
-      "OBJ_155" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-            "OBJ_156",
-            "OBJ_157",
-            "OBJ_158"
-         );
-      };
-      "OBJ_156" = {
-         isa = "PBXBuildFile";
-         fileRef = "Curry::Curry::Product";
-      };
-      "OBJ_157" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftParamTest::SwiftParamTest::Product";
-      };
-      "OBJ_158" = {
-         isa = "PBXBuildFile";
-         fileRef = "SwiftPrettyPrint::SwiftPrettyPrint::Product";
-      };
-      "OBJ_159" = {
-         isa = "PBXTargetDependency";
-         target = "Curry::Curry";
-      };
-      "OBJ_16" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_17"
-         );
-         name = "Extension";
-         path = "Extension";
-         sourceTree = "<group>";
-      };
-      "OBJ_160" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftParamTest::SwiftParamTest";
-      };
-      "OBJ_161" = {
-         isa = "PBXTargetDependency";
-         target = "SwiftPrettyPrint::SwiftPrettyPrint";
-      };
-      "OBJ_17" = {
-         isa = "PBXFileReference";
-         path = "String+extension.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_18" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_19",
-            "OBJ_20",
-            "OBJ_21"
-         );
-         name = "Public";
-         path = "Public";
-         sourceTree = "<group>";
-      };
-      "OBJ_19" = {
-         isa = "PBXFileReference";
-         path = "Debug.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_2" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_3",
-            "OBJ_4"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_20" = {
-         isa = "PBXFileReference";
-         path = "Operator.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_21" = {
-         isa = "PBXFileReference";
-         path = "Option.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_22" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_23"
-         );
-         name = "Tests";
-         path = "";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_23" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_24",
-            "OBJ_30",
-            "OBJ_32",
-            "OBJ_35"
-         );
-         name = "SwiftPrettyPrintTests";
-         path = "Tests/SwiftPrettyPrintTests";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_24" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_25",
-            "OBJ_28",
-            "OBJ_29"
-         );
-         name = "Core";
-         path = "Core";
-         sourceTree = "<group>";
-      };
-      "OBJ_25" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_26",
-            "OBJ_27"
-         );
-         name = "Formatter";
-         path = "Formatter";
-         sourceTree = "<group>";
-      };
-      "OBJ_26" = {
-         isa = "PBXFileReference";
-         path = "MultilineFormatterTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_27" = {
-         isa = "PBXFileReference";
-         path = "SinglelineFormatterTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_28" = {
-         isa = "PBXFileReference";
-         path = "PrettyTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_29" = {
-         isa = "PBXFileReference";
-         path = "UtilTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_3" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "NO";
-            DEBUG_INFORMATION_FORMAT = "dwarf";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            ENABLE_NS_ASSERTIONS = "YES";
-            GCC_OPTIMIZATION_LEVEL = "0";
-            GCC_PREPROCESSOR_DEFINITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE=1",
-               "DEBUG=1"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            ONLY_ACTIVE_ARCH = "YES";
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE",
-               "DEBUG"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Debug";
-      };
-      "OBJ_30" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_31"
-         );
-         name = "Extension";
-         path = "Extension";
-         sourceTree = "<group>";
-      };
-      "OBJ_31" = {
-         isa = "PBXFileReference";
-         path = "String+extensionTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_32" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_33",
-            "OBJ_34"
-         );
-         name = "Helper";
-         path = "Helper";
-         sourceTree = "<group>";
-      };
-      "OBJ_33" = {
-         isa = "PBXFileReference";
-         path = "Assertions.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_34" = {
-         isa = "PBXFileReference";
-         path = "DebugHelper.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_35" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_36",
-            "OBJ_37",
-            "OBJ_38"
-         );
-         name = "Public";
-         path = "Public";
-         sourceTree = "<group>";
-      };
-      "OBJ_36" = {
-         isa = "PBXFileReference";
-         path = "DebugTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_37" = {
-         isa = "PBXFileReference";
-         path = "OperatorTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_38" = {
-         isa = "PBXFileReference";
-         path = "OptionTests.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_39" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_40",
-            "OBJ_43"
-         );
-         name = "Dependencies";
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_4" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            CLANG_ENABLE_OBJC_ARC = "YES";
-            COMBINE_HIDPI_IMAGES = "YES";
-            COPY_PHASE_STRIP = "YES";
-            DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-            DYLIB_INSTALL_NAME_BASE = "@rpath";
-            GCC_OPTIMIZATION_LEVEL = "s";
-            GCC_PREPROCESSOR_DEFINITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE=1"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)",
-               "-DXcode"
-            );
-            PRODUCT_NAME = "$(TARGET_NAME)";
-            SDKROOT = "macosx";
-            SUPPORTED_PLATFORMS = (
-               "macosx",
-               "iphoneos",
-               "iphonesimulator",
-               "appletvos",
-               "appletvsimulator",
-               "watchos",
-               "watchsimulator"
-            );
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)",
-               "SWIFT_PACKAGE"
-            );
-            SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-            USE_HEADERMAP = "NO";
-         };
-         name = "Release";
-      };
-      "OBJ_40" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_41",
-            "OBJ_42"
-         );
-         name = "Curry 4.0.2";
-         path = ".build/checkouts/Curry/Source";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_41" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         name = "Package.swift";
-         path = "/Users/hosonumayuusuke/go/src/github.com/YusukeHosonuma/SwiftPrettyPrint/.build/checkouts/Curry/Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_42" = {
-         isa = "PBXFileReference";
-         path = "Curry.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_43" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_44",
-            "OBJ_45",
-            "OBJ_49",
-            "OBJ_50",
-            "OBJ_58"
-         );
-         name = "SwiftParamTest 2.2.0";
-         path = ".build/checkouts/SwiftParamTest/Sources";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_44" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         name = "Package.swift";
-         path = "/Users/hosonumayuusuke/go/src/github.com/YusukeHosonuma/SwiftPrettyPrint/.build/checkouts/SwiftParamTest/Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_45" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_46",
-            "OBJ_47",
-            "OBJ_48"
-         );
-         name = "Core";
-         path = "Core";
-         sourceTree = "<group>";
-      };
-      "OBJ_46" = {
-         isa = "PBXFileReference";
-         path = "ParameterizedTest.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_47" = {
-         isa = "PBXFileReference";
-         path = "ParameterizedTestRunner.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_48" = {
-         isa = "PBXFileReference";
-         path = "Row.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_49" = {
-         isa = "PBXFileReference";
-         path = "CustomAssertion.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_5" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_6",
-            "OBJ_7",
-            "OBJ_22",
-            "OBJ_39",
-            "OBJ_61",
-            "OBJ_66",
-            "OBJ_67",
-            "OBJ_68",
-            "OBJ_69",
-            "OBJ_70",
-            "OBJ_71",
-            "OBJ_72",
-            "OBJ_73",
-            "OBJ_74",
-            "OBJ_75",
-            "OBJ_76"
-         );
-         path = "";
-         sourceTree = "<group>";
-      };
-      "OBJ_50" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_51",
-            "OBJ_52",
-            "OBJ_54",
-            "OBJ_57"
-         );
-         name = "DSL";
-         path = "DSL";
-         sourceTree = "<group>";
-      };
-      "OBJ_51" = {
-         isa = "PBXFileReference";
-         path = "Args.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_52" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_53"
-         );
-         name = "Basic";
-         path = "Basic";
-         sourceTree = "<group>";
-      };
-      "OBJ_53" = {
-         isa = "PBXFileReference";
-         path = "BasicDSLAssert.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_54" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_55",
-            "OBJ_56"
-         );
-         name = "FunctionBuilder";
-         path = "FunctionBuilder";
-         sourceTree = "<group>";
-      };
-      "OBJ_55" = {
-         isa = "PBXFileReference";
-         path = "FunctionBuilderDSLAssert.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_56" = {
-         isa = "PBXFileReference";
-         path = "ParameterBuilder.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_57" = {
-         isa = "PBXFileReference";
-         path = "Operator.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_58" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_59",
-            "OBJ_60"
-         );
-         name = "Util";
-         path = "Util";
-         sourceTree = "<group>";
-      };
-      "OBJ_59" = {
-         isa = "PBXFileReference";
-         path = "Flatten.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_6" = {
-         isa = "PBXFileReference";
-         explicitFileType = "sourcecode.swift";
-         path = "Package.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_60" = {
-         isa = "PBXFileReference";
-         path = "MarkdownTable.swift";
-         sourceTree = "<group>";
-      };
-      "OBJ_61" = {
-         isa = "PBXGroup";
-         children = (
-            "SwiftParamTest::SwiftParamTest::Product",
-            "Curry::Curry::Product",
-            "SwiftPrettyPrint::SwiftPrettyPrintTests::Product",
-            "SwiftPrettyPrint::SwiftPrettyPrint::Product"
-         );
-         name = "Products";
-         path = "";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "OBJ_66" = {
-         isa = "PBXFileReference";
-         path = "Example";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_67" = {
-         isa = "PBXFileReference";
-         path = "Image";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_68" = {
-         isa = "PBXFileReference";
-         path = "vendor";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_69" = {
-         isa = "PBXFileReference";
-         path = "LICENSE";
-         sourceTree = "<group>";
-      };
-      "OBJ_7" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_8",
-            "OBJ_16",
-            "OBJ_18"
-         );
-         name = "Sources";
-         path = "Sources";
-         sourceTree = "SOURCE_ROOT";
-      };
-      "OBJ_70" = {
-         isa = "PBXFileReference";
-         path = "Makefile";
-         sourceTree = "<group>";
-      };
-      "OBJ_71" = {
-         isa = "PBXFileReference";
-         path = "README.md";
-         sourceTree = "<group>";
-      };
-      "OBJ_72" = {
-         isa = "PBXFileReference";
-         path = "SwiftPrettyPrint.podspec";
-         sourceTree = "<group>";
-      };
-      "OBJ_73" = {
-         isa = "PBXFileReference";
-         path = "Gemfile";
-         sourceTree = "<group>";
-      };
-      "OBJ_74" = {
-         isa = "PBXFileReference";
-         path = "Gemfile.lock";
-         sourceTree = "<group>";
-      };
-      "OBJ_75" = {
-         isa = "PBXFileReference";
-         path = "Brewfile";
-         sourceTree = "<group>";
-      };
-      "OBJ_76" = {
-         isa = "PBXFileReference";
-         path = "version.txt";
-         sourceTree = "<group>";
-      };
-      "OBJ_78" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_79",
-            "OBJ_80"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_79" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftPrettyPrint.xcodeproj/Curry_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Curry";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.2";
-            TARGET_NAME = "Curry";
-         };
-         name = "Debug";
-      };
-      "OBJ_8" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_9",
-            "OBJ_13",
-            "OBJ_14",
-            "OBJ_15"
-         );
-         name = "Core";
-         path = "Core";
-         sourceTree = "<group>";
-      };
-      "OBJ_80" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftPrettyPrint.xcodeproj/Curry_Info.plist";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "Curry";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "4.2";
-            TARGET_NAME = "Curry";
-         };
-         name = "Release";
-      };
-      "OBJ_81" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_82"
-         );
-      };
-      "OBJ_82" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_42";
-      };
-      "OBJ_83" = {
-         isa = "PBXFrameworksBuildPhase";
-         files = (
-         );
-      };
-      "OBJ_85" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_86",
-            "OBJ_87"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_86" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4.2",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "4.2"
-            );
-            SWIFT_VERSION = "4.2";
-         };
-         name = "Debug";
-      };
-      "OBJ_87" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            LD = "/usr/bin/true";
-            OTHER_SWIFT_FLAGS = (
-               "-swift-version",
-               "4.2",
-               "-I",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2",
-               "-target",
-               "x86_64-apple-macosx10.10",
-               "-sdk",
-               "/Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk",
-               "-package-description-version",
-               "4.2"
-            );
-            SWIFT_VERSION = "4.2";
-         };
-         name = "Release";
-      };
-      "OBJ_88" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_89"
-         );
-      };
-      "OBJ_89" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_41";
-      };
-      "OBJ_9" = {
-         isa = "PBXGroup";
-         children = (
-            "OBJ_10",
-            "OBJ_11",
-            "OBJ_12"
-         );
-         name = "Formatter";
-         path = "Formatter";
-         sourceTree = "<group>";
-      };
-      "OBJ_91" = {
-         isa = "XCConfigurationList";
-         buildConfigurations = (
-            "OBJ_92",
-            "OBJ_93"
-         );
-         defaultConfigurationIsVisible = "0";
-         defaultConfigurationName = "Release";
-      };
-      "OBJ_92" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftPrettyPrint.xcodeproj/SwiftParamTest_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftParamTest";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftParamTest";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Debug";
-      };
-      "OBJ_93" = {
-         isa = "XCBuildConfiguration";
-         buildSettings = {
-            ENABLE_TESTABILITY = "YES";
-            FRAMEWORK_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(PLATFORM_DIR)/Developer/Library/Frameworks"
-            );
-            HEADER_SEARCH_PATHS = (
-               "$(inherited)"
-            );
-            INFOPLIST_FILE = "SwiftPrettyPrint.xcodeproj/SwiftParamTest_Info.plist";
-            IPHONEOS_DEPLOYMENT_TARGET = "8.0";
-            LD_RUNPATH_SEARCH_PATHS = (
-               "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
-            );
-            MACOSX_DEPLOYMENT_TARGET = "10.10";
-            OTHER_CFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_LDFLAGS = (
-               "$(inherited)"
-            );
-            OTHER_SWIFT_FLAGS = (
-               "$(inherited)"
-            );
-            PRODUCT_BUNDLE_IDENTIFIER = "SwiftParamTest";
-            PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
-            PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-            SKIP_INSTALL = "YES";
-            SWIFT_ACTIVE_COMPILATION_CONDITIONS = (
-               "$(inherited)"
-            );
-            SWIFT_VERSION = "5.0";
-            TARGET_NAME = "SwiftParamTest";
-            TVOS_DEPLOYMENT_TARGET = "9.0";
-            WATCHOS_DEPLOYMENT_TARGET = "2.0";
-         };
-         name = "Release";
-      };
-      "OBJ_94" = {
-         isa = "PBXSourcesBuildPhase";
-         files = (
-            "OBJ_95",
-            "OBJ_96",
-            "OBJ_97",
-            "OBJ_98",
-            "OBJ_99",
-            "OBJ_100",
-            "OBJ_101",
-            "OBJ_102",
-            "OBJ_103",
-            "OBJ_104",
-            "OBJ_105"
-         );
-      };
-      "OBJ_95" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_46";
-      };
-      "OBJ_96" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_47";
-      };
-      "OBJ_97" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_48";
-      };
-      "OBJ_98" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_49";
-      };
-      "OBJ_99" = {
-         isa = "PBXBuildFile";
-         fileRef = "OBJ_51";
-      };
-      "SwiftParamTest::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_108";
-         buildPhases = (
-            "OBJ_111"
-         );
-         dependencies = (
-         );
-         name = "SwiftParamTestPackageDescription";
-         productName = "SwiftParamTestPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftParamTest::SwiftParamTest" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_91";
-         buildPhases = (
-            "OBJ_94",
-            "OBJ_106"
-         );
-         dependencies = (
-         );
-         name = "SwiftParamTest";
-         productName = "SwiftParamTest";
-         productReference = "SwiftParamTest::SwiftParamTest::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftParamTest::SwiftParamTest::Product" = {
-         isa = "PBXFileReference";
-         path = "SwiftParamTest.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SwiftPrettyPrint::SwiftPMPackageDescription" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_130";
-         buildPhases = (
-            "OBJ_133"
-         );
-         dependencies = (
-         );
-         name = "SwiftPrettyPrintPackageDescription";
-         productName = "SwiftPrettyPrintPackageDescription";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftPrettyPrint::SwiftPrettyPrint" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_114";
-         buildPhases = (
-            "OBJ_117",
-            "OBJ_128"
-         );
-         dependencies = (
-         );
-         name = "SwiftPrettyPrint";
-         productName = "SwiftPrettyPrint";
-         productReference = "SwiftPrettyPrint::SwiftPrettyPrint::Product";
-         productType = "com.apple.product-type.framework";
-      };
-      "SwiftPrettyPrint::SwiftPrettyPrint::Product" = {
-         isa = "PBXFileReference";
-         path = "SwiftPrettyPrint.framework";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-      "SwiftPrettyPrint::SwiftPrettyPrintPackageTests::ProductTarget" = {
-         isa = "PBXAggregateTarget";
-         buildConfigurationList = "OBJ_136";
-         buildPhases = (
-         );
-         dependencies = (
-            "OBJ_139"
-         );
-         name = "SwiftPrettyPrintPackageTests";
-         productName = "SwiftPrettyPrintPackageTests";
-      };
-      "SwiftPrettyPrint::SwiftPrettyPrintTests" = {
-         isa = "PBXNativeTarget";
-         buildConfigurationList = "OBJ_141";
-         buildPhases = (
-            "OBJ_144",
-            "OBJ_155"
-         );
-         dependencies = (
-            "OBJ_159",
-            "OBJ_160",
-            "OBJ_161"
-         );
-         name = "SwiftPrettyPrintTests";
-         productName = "SwiftPrettyPrintTests";
-         productReference = "SwiftPrettyPrint::SwiftPrettyPrintTests::Product";
-         productType = "com.apple.product-type.bundle.unit-test";
-      };
-      "SwiftPrettyPrint::SwiftPrettyPrintTests::Product" = {
-         isa = "PBXFileReference";
-         path = "SwiftPrettyPrintTests.xctest";
-         sourceTree = "BUILT_PRODUCTS_DIR";
-      };
-   };
-   rootObject = "OBJ_1";
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		"SwiftPrettyPrint::SwiftPrettyPrintPackageTests::ProductTarget" /* SwiftPrettyPrintPackageTests */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = OBJ_136 /* Build configuration list for PBXAggregateTarget "SwiftPrettyPrintPackageTests" */;
+			buildPhases = (
+			);
+			dependencies = (
+				OBJ_139 /* PBXTargetDependency */,
+			);
+			name = SwiftPrettyPrintPackageTests;
+			productName = SwiftPrettyPrintPackageTests;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		OBJ_100 /* BasicDSLAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* BasicDSLAssert.swift */; };
+		OBJ_101 /* FunctionBuilderDSLAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_55 /* FunctionBuilderDSLAssert.swift */; };
+		OBJ_102 /* ParameterBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_56 /* ParameterBuilder.swift */; };
+		OBJ_103 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_57 /* Operator.swift */; };
+		OBJ_104 /* Flatten.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_59 /* Flatten.swift */; };
+		OBJ_105 /* MarkdownTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_60 /* MarkdownTable.swift */; };
+		OBJ_112 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* Package.swift */; };
+		OBJ_118 /* MultilineFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* MultilineFormatter.swift */; };
+		OBJ_119 /* PrettyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* PrettyFormatter.swift */; };
+		OBJ_120 /* SinglelineFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* SinglelineFormatter.swift */; };
+		OBJ_121 /* PrettyDescriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* PrettyDescriber.swift */; };
+		OBJ_122 /* PrettyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* PrettyError.swift */; };
+		OBJ_123 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Util.swift */; };
+		OBJ_124 /* String+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* String+extension.swift */; };
+		OBJ_125 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* Debug.swift */; };
+		OBJ_126 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Operator.swift */; };
+		OBJ_127 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Option.swift */; };
+		OBJ_134 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_145 /* MultilineFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* MultilineFormatterTests.swift */; };
+		OBJ_146 /* SinglelineFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* SinglelineFormatterTests.swift */; };
+		OBJ_147 /* PrettyDescriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* PrettyDescriberTests.swift */; };
+		OBJ_148 /* UtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_29 /* UtilTests.swift */; };
+		OBJ_149 /* String+extensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* String+extensionTests.swift */; };
+		OBJ_150 /* Assertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* Assertions.swift */; };
+		OBJ_151 /* DebugHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* DebugHelper.swift */; };
+		OBJ_152 /* DebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_36 /* DebugTests.swift */; };
+		OBJ_153 /* OperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* OperatorTests.swift */; };
+		OBJ_154 /* OptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* OptionTests.swift */; };
+		OBJ_156 /* Curry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Curry::Curry::Product" /* Curry.framework */; };
+		OBJ_157 /* SwiftParamTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftParamTest::SwiftParamTest::Product" /* SwiftParamTest.framework */; };
+		OBJ_158 /* SwiftPrettyPrint.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftPrettyPrint::SwiftPrettyPrint::Product" /* SwiftPrettyPrint.framework */; };
+		OBJ_82 /* Curry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_42 /* Curry.swift */; };
+		OBJ_89 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* Package.swift */; };
+		OBJ_95 /* ParameterizedTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_46 /* ParameterizedTest.swift */; };
+		OBJ_96 /* ParameterizedTestRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* ParameterizedTestRunner.swift */; };
+		OBJ_97 /* Row.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_48 /* Row.swift */; };
+		OBJ_98 /* CustomAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_49 /* CustomAssertion.swift */; };
+		OBJ_99 /* Args.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_51 /* Args.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		E5D770692434344B00CEAB96 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "Curry::Curry";
+			remoteInfo = Curry;
+		};
+		E5D7706A2434344B00CEAB96 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftParamTest::SwiftParamTest";
+			remoteInfo = SwiftParamTest;
+		};
+		E5D7706B2434344B00CEAB96 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftPrettyPrint::SwiftPrettyPrint";
+			remoteInfo = SwiftPrettyPrint;
+		};
+		E5EC299E243434EA00331A06 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = OBJ_1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "SwiftPrettyPrint::SwiftPrettyPrintTests";
+			remoteInfo = SwiftPrettyPrintTests;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		"Curry::Curry::Product" /* Curry.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Curry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_10 /* MultilineFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineFormatter.swift; sourceTree = "<group>"; };
+		OBJ_11 /* PrettyFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyFormatter.swift; sourceTree = "<group>"; };
+		OBJ_12 /* SinglelineFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglelineFormatter.swift; sourceTree = "<group>"; };
+		OBJ_13 /* PrettyDescriber.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyDescriber.swift; sourceTree = "<group>"; };
+		OBJ_14 /* PrettyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyError.swift; sourceTree = "<group>"; };
+		OBJ_15 /* Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
+		OBJ_17 /* String+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extension.swift"; sourceTree = "<group>"; };
+		OBJ_19 /* Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
+		OBJ_20 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		OBJ_21 /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
+		OBJ_26 /* MultilineFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineFormatterTests.swift; sourceTree = "<group>"; };
+		OBJ_27 /* SinglelineFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglelineFormatterTests.swift; sourceTree = "<group>"; };
+		OBJ_28 /* PrettyDescriberTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyDescriberTests.swift; sourceTree = "<group>"; };
+		OBJ_29 /* UtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilTests.swift; sourceTree = "<group>"; };
+		OBJ_31 /* String+extensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extensionTests.swift"; sourceTree = "<group>"; };
+		OBJ_33 /* Assertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assertions.swift; sourceTree = "<group>"; };
+		OBJ_34 /* DebugHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugHelper.swift; sourceTree = "<group>"; };
+		OBJ_36 /* DebugTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugTests.swift; sourceTree = "<group>"; };
+		OBJ_37 /* OperatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperatorTests.swift; sourceTree = "<group>"; };
+		OBJ_38 /* OptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionTests.swift; sourceTree = "<group>"; };
+		OBJ_41 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/hosonumayuusuke/go/src/github.com/YusukeHosonuma/SwiftPrettyPrint/.build/checkouts/Curry/Package.swift; sourceTree = "<group>"; };
+		OBJ_42 /* Curry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Curry.swift; sourceTree = "<group>"; };
+		OBJ_44 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/hosonumayuusuke/go/src/github.com/YusukeHosonuma/SwiftPrettyPrint/.build/checkouts/SwiftParamTest/Package.swift; sourceTree = "<group>"; };
+		OBJ_46 /* ParameterizedTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterizedTest.swift; sourceTree = "<group>"; };
+		OBJ_47 /* ParameterizedTestRunner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterizedTestRunner.swift; sourceTree = "<group>"; };
+		OBJ_48 /* Row.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Row.swift; sourceTree = "<group>"; };
+		OBJ_49 /* CustomAssertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAssertion.swift; sourceTree = "<group>"; };
+		OBJ_51 /* Args.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Args.swift; sourceTree = "<group>"; };
+		OBJ_53 /* BasicDSLAssert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicDSLAssert.swift; sourceTree = "<group>"; };
+		OBJ_55 /* FunctionBuilderDSLAssert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionBuilderDSLAssert.swift; sourceTree = "<group>"; };
+		OBJ_56 /* ParameterBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterBuilder.swift; sourceTree = "<group>"; };
+		OBJ_57 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
+		OBJ_59 /* Flatten.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flatten.swift; sourceTree = "<group>"; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_60 /* MarkdownTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownTable.swift; sourceTree = "<group>"; };
+		OBJ_66 /* Example */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Example; sourceTree = SOURCE_ROOT; };
+		OBJ_67 /* Image */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Image; sourceTree = SOURCE_ROOT; };
+		OBJ_68 /* vendor */ = {isa = PBXFileReference; lastKnownFileType = folder; path = vendor; sourceTree = SOURCE_ROOT; };
+		OBJ_69 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		OBJ_70 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		OBJ_71 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		OBJ_72 /* SwiftPrettyPrint.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = SwiftPrettyPrint.podspec; sourceTree = "<group>"; };
+		OBJ_73 /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = "<group>"; };
+		OBJ_74 /* Gemfile.lock */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile.lock; sourceTree = "<group>"; };
+		OBJ_75 /* Brewfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Brewfile; sourceTree = "<group>"; };
+		OBJ_76 /* version.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = version.txt; sourceTree = "<group>"; };
+		"SwiftParamTest::SwiftParamTest::Product" /* SwiftParamTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftParamTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SwiftPrettyPrint::SwiftPrettyPrint::Product" /* SwiftPrettyPrint.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftPrettyPrint.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"SwiftPrettyPrint::SwiftPrettyPrintTests::Product" /* SwiftPrettyPrintTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = SwiftPrettyPrintTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		OBJ_106 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_128 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_155 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_156 /* Curry.framework in Frameworks */,
+				OBJ_157 /* SwiftParamTest.framework in Frameworks */,
+				OBJ_158 /* SwiftPrettyPrint.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_83 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		OBJ_16 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_17 /* String+extension.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		OBJ_18 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_19 /* Debug.swift */,
+				OBJ_20 /* Operator.swift */,
+				OBJ_21 /* Option.swift */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
+		OBJ_22 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_23 /* SwiftPrettyPrintTests */,
+			);
+			name = Tests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_23 /* SwiftPrettyPrintTests */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_24 /* Core */,
+				OBJ_30 /* Extension */,
+				OBJ_32 /* Helper */,
+				OBJ_35 /* Public */,
+			);
+			name = SwiftPrettyPrintTests;
+			path = Tests/SwiftPrettyPrintTests;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_24 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_25 /* Formatter */,
+				OBJ_28 /* PrettyDescriberTests.swift */,
+				OBJ_29 /* UtilTests.swift */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		OBJ_25 /* Formatter */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_26 /* MultilineFormatterTests.swift */,
+				OBJ_27 /* SinglelineFormatterTests.swift */,
+			);
+			path = Formatter;
+			sourceTree = "<group>";
+		};
+		OBJ_30 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_31 /* String+extensionTests.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
+		OBJ_32 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_33 /* Assertions.swift */,
+				OBJ_34 /* DebugHelper.swift */,
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
+		OBJ_35 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_36 /* DebugTests.swift */,
+				OBJ_37 /* OperatorTests.swift */,
+				OBJ_38 /* OptionTests.swift */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
+		OBJ_39 /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_40 /* Curry 4.0.2 */,
+				OBJ_43 /* SwiftParamTest 2.2.0 */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
+		OBJ_40 /* Curry 4.0.2 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_41 /* Package.swift */,
+				OBJ_42 /* Curry.swift */,
+			);
+			name = "Curry 4.0.2";
+			path = .build/checkouts/Curry/Source;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_43 /* SwiftParamTest 2.2.0 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_44 /* Package.swift */,
+				OBJ_45 /* Core */,
+				OBJ_49 /* CustomAssertion.swift */,
+				OBJ_50 /* DSL */,
+				OBJ_58 /* Util */,
+			);
+			name = "SwiftParamTest 2.2.0";
+			path = .build/checkouts/SwiftParamTest/Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_45 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_46 /* ParameterizedTest.swift */,
+				OBJ_47 /* ParameterizedTestRunner.swift */,
+				OBJ_48 /* Row.swift */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		OBJ_5 = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_22 /* Tests */,
+				OBJ_39 /* Dependencies */,
+				OBJ_61 /* Products */,
+				OBJ_66 /* Example */,
+				OBJ_67 /* Image */,
+				OBJ_68 /* vendor */,
+				OBJ_69 /* LICENSE */,
+				OBJ_70 /* Makefile */,
+				OBJ_71 /* README.md */,
+				OBJ_72 /* SwiftPrettyPrint.podspec */,
+				OBJ_73 /* Gemfile */,
+				OBJ_74 /* Gemfile.lock */,
+				OBJ_75 /* Brewfile */,
+				OBJ_76 /* version.txt */,
+			);
+			sourceTree = "<group>";
+		};
+		OBJ_50 /* DSL */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_51 /* Args.swift */,
+				OBJ_52 /* Basic */,
+				OBJ_54 /* FunctionBuilder */,
+				OBJ_57 /* Operator.swift */,
+			);
+			path = DSL;
+			sourceTree = "<group>";
+		};
+		OBJ_52 /* Basic */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_53 /* BasicDSLAssert.swift */,
+			);
+			path = Basic;
+			sourceTree = "<group>";
+		};
+		OBJ_54 /* FunctionBuilder */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_55 /* FunctionBuilderDSLAssert.swift */,
+				OBJ_56 /* ParameterBuilder.swift */,
+			);
+			path = FunctionBuilder;
+			sourceTree = "<group>";
+		};
+		OBJ_58 /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_59 /* Flatten.swift */,
+				OBJ_60 /* MarkdownTable.swift */,
+			);
+			path = Util;
+			sourceTree = "<group>";
+		};
+		OBJ_61 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				"SwiftParamTest::SwiftParamTest::Product" /* SwiftParamTest.framework */,
+				"Curry::Curry::Product" /* Curry.framework */,
+				"SwiftPrettyPrint::SwiftPrettyPrintTests::Product" /* SwiftPrettyPrintTests.xctest */,
+				"SwiftPrettyPrint::SwiftPrettyPrint::Product" /* SwiftPrettyPrint.framework */,
+			);
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* Core */,
+				OBJ_16 /* Extension */,
+				OBJ_18 /* Public */,
+			);
+			path = Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_8 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* Formatter */,
+				OBJ_13 /* PrettyDescriber.swift */,
+				OBJ_14 /* PrettyError.swift */,
+				OBJ_15 /* Util.swift */,
+			);
+			path = Core;
+			sourceTree = "<group>";
+		};
+		OBJ_9 /* Formatter */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_10 /* MultilineFormatter.swift */,
+				OBJ_11 /* PrettyFormatter.swift */,
+				OBJ_12 /* SinglelineFormatter.swift */,
+			);
+			path = Formatter;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		"Curry::Curry" /* Curry */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_78 /* Build configuration list for PBXNativeTarget "Curry" */;
+			buildPhases = (
+				OBJ_81 /* Sources */,
+				OBJ_83 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Curry;
+			productName = Curry;
+			productReference = "Curry::Curry::Product" /* Curry.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"Curry::SwiftPMPackageDescription" /* CurryPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_85 /* Build configuration list for PBXNativeTarget "CurryPackageDescription" */;
+			buildPhases = (
+				OBJ_88 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CurryPackageDescription;
+			productName = CurryPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftParamTest::SwiftPMPackageDescription" /* SwiftParamTestPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_108 /* Build configuration list for PBXNativeTarget "SwiftParamTestPackageDescription" */;
+			buildPhases = (
+				OBJ_111 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftParamTestPackageDescription;
+			productName = SwiftParamTestPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftParamTest::SwiftParamTest" /* SwiftParamTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_91 /* Build configuration list for PBXNativeTarget "SwiftParamTest" */;
+			buildPhases = (
+				OBJ_94 /* Sources */,
+				OBJ_106 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftParamTest;
+			productName = SwiftParamTest;
+			productReference = "SwiftParamTest::SwiftParamTest::Product" /* SwiftParamTest.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftPrettyPrint::SwiftPMPackageDescription" /* SwiftPrettyPrintPackageDescription */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_130 /* Build configuration list for PBXNativeTarget "SwiftPrettyPrintPackageDescription" */;
+			buildPhases = (
+				OBJ_133 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftPrettyPrintPackageDescription;
+			productName = SwiftPrettyPrintPackageDescription;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftPrettyPrint::SwiftPrettyPrint" /* SwiftPrettyPrint */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_114 /* Build configuration list for PBXNativeTarget "SwiftPrettyPrint" */;
+			buildPhases = (
+				OBJ_117 /* Sources */,
+				OBJ_128 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftPrettyPrint;
+			productName = SwiftPrettyPrint;
+			productReference = "SwiftPrettyPrint::SwiftPrettyPrint::Product" /* SwiftPrettyPrint.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		"SwiftPrettyPrint::SwiftPrettyPrintTests" /* SwiftPrettyPrintTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = OBJ_141 /* Build configuration list for PBXNativeTarget "SwiftPrettyPrintTests" */;
+			buildPhases = (
+				OBJ_144 /* Sources */,
+				OBJ_155 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				OBJ_159 /* PBXTargetDependency */,
+				OBJ_160 /* PBXTargetDependency */,
+				OBJ_161 /* PBXTargetDependency */,
+			);
+			name = SwiftPrettyPrintTests;
+			productName = SwiftPrettyPrintTests;
+			productReference = "SwiftPrettyPrint::SwiftPrettyPrintTests::Product" /* SwiftPrettyPrintTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		OBJ_1 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftMigration = 9999;
+				LastUpgradeCheck = 9999;
+			};
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "SwiftPrettyPrint" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = OBJ_5;
+			productRefGroup = OBJ_61 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				"Curry::Curry" /* Curry */,
+				"Curry::SwiftPMPackageDescription" /* CurryPackageDescription */,
+				"SwiftParamTest::SwiftParamTest" /* SwiftParamTest */,
+				"SwiftParamTest::SwiftPMPackageDescription" /* SwiftParamTestPackageDescription */,
+				"SwiftPrettyPrint::SwiftPrettyPrint" /* SwiftPrettyPrint */,
+				"SwiftPrettyPrint::SwiftPMPackageDescription" /* SwiftPrettyPrintPackageDescription */,
+				"SwiftPrettyPrint::SwiftPrettyPrintPackageTests::ProductTarget" /* SwiftPrettyPrintPackageTests */,
+				"SwiftPrettyPrint::SwiftPrettyPrintTests" /* SwiftPrettyPrintTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		OBJ_111 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_112 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_117 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_118 /* MultilineFormatter.swift in Sources */,
+				OBJ_119 /* PrettyFormatter.swift in Sources */,
+				OBJ_120 /* SinglelineFormatter.swift in Sources */,
+				OBJ_121 /* PrettyDescriber.swift in Sources */,
+				OBJ_122 /* PrettyError.swift in Sources */,
+				OBJ_123 /* Util.swift in Sources */,
+				OBJ_124 /* String+extension.swift in Sources */,
+				OBJ_125 /* Debug.swift in Sources */,
+				OBJ_126 /* Operator.swift in Sources */,
+				OBJ_127 /* Option.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_133 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_134 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_144 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_145 /* MultilineFormatterTests.swift in Sources */,
+				OBJ_146 /* SinglelineFormatterTests.swift in Sources */,
+				OBJ_147 /* PrettyDescriberTests.swift in Sources */,
+				OBJ_148 /* UtilTests.swift in Sources */,
+				OBJ_149 /* String+extensionTests.swift in Sources */,
+				OBJ_150 /* Assertions.swift in Sources */,
+				OBJ_151 /* DebugHelper.swift in Sources */,
+				OBJ_152 /* DebugTests.swift in Sources */,
+				OBJ_153 /* OperatorTests.swift in Sources */,
+				OBJ_154 /* OptionTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_81 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_82 /* Curry.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_88 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_89 /* Package.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_94 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_95 /* ParameterizedTest.swift in Sources */,
+				OBJ_96 /* ParameterizedTestRunner.swift in Sources */,
+				OBJ_97 /* Row.swift in Sources */,
+				OBJ_98 /* CustomAssertion.swift in Sources */,
+				OBJ_99 /* Args.swift in Sources */,
+				OBJ_100 /* BasicDSLAssert.swift in Sources */,
+				OBJ_101 /* FunctionBuilderDSLAssert.swift in Sources */,
+				OBJ_102 /* ParameterBuilder.swift in Sources */,
+				OBJ_103 /* Operator.swift in Sources */,
+				OBJ_104 /* Flatten.swift in Sources */,
+				OBJ_105 /* MarkdownTable.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		OBJ_139 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftPrettyPrint::SwiftPrettyPrintTests" /* SwiftPrettyPrintTests */;
+			targetProxy = E5EC299E243434EA00331A06 /* PBXContainerItemProxy */;
+		};
+		OBJ_159 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Curry::Curry" /* Curry */;
+			targetProxy = E5D770692434344B00CEAB96 /* PBXContainerItemProxy */;
+		};
+		OBJ_160 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftParamTest::SwiftParamTest" /* SwiftParamTest */;
+			targetProxy = E5D7706A2434344B00CEAB96 /* PBXContainerItemProxy */;
+		};
+		OBJ_161 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftPrettyPrint::SwiftPrettyPrint" /* SwiftPrettyPrint */;
+			targetProxy = E5D7706B2434344B00CEAB96 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		OBJ_109 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.1";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_110 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.1";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_115 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftPrettyPrint.xcodeproj/SwiftPrettyPrint_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftPrettyPrint;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftPrettyPrint;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_116 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftPrettyPrint.xcodeproj/SwiftPrettyPrint_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftPrettyPrint;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftPrettyPrint;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_131 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.1";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		OBJ_132 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.1";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		OBJ_137 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		OBJ_138 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		OBJ_142 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftPrettyPrint.xcodeproj/SwiftPrettyPrintTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftPrettyPrintTests;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_143 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftPrettyPrint.xcodeproj/SwiftPrettyPrintTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftPrettyPrintTests;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+					"DEBUG=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE DEBUG";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"SWIFT_PACKAGE=1",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		OBJ_79 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftPrettyPrint.xcodeproj/Curry_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Curry;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.2;
+				TARGET_NAME = Curry;
+			};
+			name = Debug;
+		};
+		OBJ_80 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftPrettyPrint.xcodeproj/Curry_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = Curry;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 4.2;
+				TARGET_NAME = Curry;
+			};
+			name = Release;
+		};
+		OBJ_86 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		OBJ_87 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD = /usr/bin/true;
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode_11.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2";
+				SWIFT_VERSION = 4.2;
+			};
+			name = Release;
+		};
+		OBJ_92 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftPrettyPrint.xcodeproj/SwiftParamTest_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftParamTest;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftParamTest;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		OBJ_93 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftPrettyPrint.xcodeproj/SwiftParamTest_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "$(inherited)";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				PRODUCT_BUNDLE_IDENTIFIER = SwiftParamTest;
+				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = SwiftParamTest;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		OBJ_108 /* Build configuration list for PBXNativeTarget "SwiftParamTestPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_109 /* Debug */,
+				OBJ_110 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_114 /* Build configuration list for PBXNativeTarget "SwiftPrettyPrint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_115 /* Debug */,
+				OBJ_116 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_130 /* Build configuration list for PBXNativeTarget "SwiftPrettyPrintPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_131 /* Debug */,
+				OBJ_132 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_136 /* Build configuration list for PBXAggregateTarget "SwiftPrettyPrintPackageTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_137 /* Debug */,
+				OBJ_138 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_141 /* Build configuration list for PBXNativeTarget "SwiftPrettyPrintTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_142 /* Debug */,
+				OBJ_143 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_2 /* Build configuration list for PBXProject "SwiftPrettyPrint" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_78 /* Build configuration list for PBXNativeTarget "Curry" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_79 /* Debug */,
+				OBJ_80 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_85 /* Build configuration list for PBXNativeTarget "CurryPackageDescription" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_86 /* Debug */,
+				OBJ_87 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		OBJ_91 /* Build configuration list for PBXNativeTarget "SwiftParamTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				OBJ_92 /* Debug */,
+				OBJ_93 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = OBJ_1 /* Project object */;
 }

--- a/SwiftPrettyPrint.xcodeproj/project.pbxproj
+++ b/SwiftPrettyPrint.xcodeproj/project.pbxproj
@@ -35,7 +35,7 @@
 		OBJ_122 /* PrettyDescriberError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* PrettyDescriberError.swift */; };
 		OBJ_123 /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* Util.swift */; };
 		OBJ_124 /* String+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* String+extension.swift */; };
-		OBJ_125 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* Debug.swift */; };
+		OBJ_125 /* Pretty.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_19 /* Pretty.swift */; };
 		OBJ_126 /* Operator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* Operator.swift */; };
 		OBJ_127 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Option.swift */; };
 		OBJ_134 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
@@ -101,7 +101,7 @@
 		OBJ_14 /* PrettyDescriberError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrettyDescriberError.swift; sourceTree = "<group>"; };
 		OBJ_15 /* Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
 		OBJ_17 /* String+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extension.swift"; sourceTree = "<group>"; };
-		OBJ_19 /* Debug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug.swift; sourceTree = "<group>"; };
+		OBJ_19 /* Pretty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pretty.swift; sourceTree = "<group>"; };
 		OBJ_20 /* Operator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operator.swift; sourceTree = "<group>"; };
 		OBJ_21 /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
 		OBJ_26 /* MultilineFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineFormatterTests.swift; sourceTree = "<group>"; };
@@ -191,7 +191,7 @@
 		OBJ_18 /* Public */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_19 /* Debug.swift */,
+				OBJ_19 /* Pretty.swift */,
 				OBJ_20 /* Operator.swift */,
 				OBJ_21 /* Option.swift */,
 			);
@@ -572,7 +572,7 @@
 				OBJ_122 /* PrettyDescriberError.swift in Sources */,
 				OBJ_123 /* Util.swift in Sources */,
 				OBJ_124 /* String+extension.swift in Sources */,
-				OBJ_125 /* Debug.swift in Sources */,
+				OBJ_125 /* Pretty.swift in Sources */,
 				OBJ_126 /* Operator.swift in Sources */,
 				OBJ_127 /* Option.swift in Sources */,
 			);

--- a/SwiftPrettyPrint.xcodeproj/xcshareddata/xcschemes/SwiftPrettyPrint-Package.xcscheme
+++ b/SwiftPrettyPrint.xcodeproj/xcshareddata/xcschemes/SwiftPrettyPrint-Package.xcscheme
@@ -1,33 +1,68 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Scheme LastUpgradeVersion = "9999" version = "1.3">
-  <BuildAction parallelizeBuildables = "YES" buildImplicitDependencies = "YES">
-    <BuildActionEntries>
-      <BuildActionEntry buildForTesting = "YES" buildForRunning = "YES" buildForProfiling = "YES" buildForArchiving = "YES" buildForAnalyzing = "YES">
-        <BuildableReference
-          BuildableIdentifier = "primary"
-          BuildableName = "'lib$(TARGET_NAME)'"
-          BlueprintName = "SwiftPrettyPrint"
-          ReferencedContainer = "container:SwiftPrettyPrint.xcodeproj">
-        </BuildableReference>
-      </BuildActionEntry>
-    </BuildActionEntries>
-  </BuildAction>
-  <TestAction
-    buildConfiguration = "Debug"
-    selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-    selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-    shouldUseLaunchSchemeArgsEnv = "YES"
-    codeCoverageEnabled = "NO">
-    <Testables>
-        <TestableReference
-          skipped = "NO">
-          <BuildableReference
-            BuildableIdentifier = "primary"
-            BuildableName = "'$(TARGET_NAME)'"
-            BlueprintName = "SwiftPrettyPrintTests"
-            ReferencedContainer = "container:SwiftPrettyPrint.xcodeproj">
-          </BuildableReference>
-        </TestableReference>
-    </Testables>
-  </TestAction>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SwiftPrettyPrint::SwiftPrettyPrint"
+               BuildableName = "SwiftPrettyPrint.framework"
+               BlueprintName = "SwiftPrettyPrint"
+               ReferencedContainer = "container:SwiftPrettyPrint.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SwiftPrettyPrint::SwiftPrettyPrintTests"
+               BuildableName = "SwiftPrettyPrintTests.xctest"
+               BlueprintName = "SwiftPrettyPrintTests"
+               ReferencedContainer = "container:SwiftPrettyPrint.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
 </Scheme>

--- a/Tests/SwiftPrettyPrintTests/Core/Formatter/MultilineFormatterTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Core/Formatter/MultilineFormatterTests.swift
@@ -213,7 +213,7 @@ class MultilineFormatterTests: XCTestCase {
     
     // MARK: - Helper
         
-    private func option(indent: Int) -> Debug.Option {
-        Debug.Option(prefix: "", indentSize: indent)
+    private func option(indent: Int) -> Pretty.Option {
+        Pretty.Option(prefix: "", indentSize: indent)
     }
 }

--- a/Tests/SwiftPrettyPrintTests/Core/PrettyDescriberTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Core/PrettyDescriberTests.swift
@@ -1,5 +1,5 @@
 //
-// PrettyTests.swift
+// PrettyDescriberTests.swift
 // SwiftPrettyPrint
 //
 // Created by Yusuke Hosonuma on 2020/02/27.
@@ -11,8 +11,8 @@ import XCTest
 import SwiftParamTest
 import Curry
 
-class PrettyTests: XCTestCase {
-    let pretty = Pretty(formatter: SinglelineFormatter())
+class PrettyDescriberTests: XCTestCase {
+    let describer = PrettyDescriber(formatter: SinglelineFormatter())
 
     override func setUp() {}
 
@@ -24,14 +24,14 @@ class PrettyTests: XCTestCase {
     func testBasicType_supportExplicitly() {
         
         // String
-        assert(to: pretty.string, header: ["target", "debug"]) {
+        assert(to: describer.string, header: ["target", "debug"]) {
             args("Hello", false, expect: #""Hello""#)
             args("Hello", true,  expect: #""Hello""#) // not display type because obvious
         }
 
         // URL
         let url = URL(string: "https://www.google.com/")!
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(url, false, expect: "https://www.google.com/")
             args(url, true,  expect: #"URL("https://www.google.com/")"#)
         }
@@ -42,8 +42,8 @@ class PrettyTests: XCTestCase {
             formatter.dateFormat = "yyyy-MM-dd HH:mm:ss ZZZZZ"
             let date = formatter.date(from: "2020-03-24 10:00:00 +0900")!
 
-            let pretty = Pretty(formatter: SinglelineFormatter(),
-                                timeZone: TimeZone(identifier: "Asia/Tokyo")!)
+            let pretty = PrettyDescriber(formatter: SinglelineFormatter(),
+                                         timeZone: TimeZone(identifier: "Asia/Tokyo")!)
 
             assert(to: pretty.string) {
                 args(date, false, expect: "2020-03-24 10:00:00")
@@ -58,25 +58,25 @@ class PrettyTests: XCTestCase {
     func testBasicType_supportNotExplicitly() {
         
         // Int
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(42, false, expect: "42")
             args(42, true,  expect: "42") // not display type because obvious
         }
 
         // Float
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(10.4 as Float, false, expect: "10.4")
             args(10.4 as Float, true,  expect: "10.4") // not display type because obvious
         }
 
         // Double
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(10.4 as Double, false, expect: "10.4")
             args(10.4 as Double, true,  expect: "10.4") // not display type because obvious
         }
         
         // Bool
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(true,  false, expect: "true")
             args(true,  true,  expect: "true") // not display type because obvious
             args(false, false, expect: "false")
@@ -84,13 +84,13 @@ class PrettyTests: XCTestCase {
         }
 
         // Range
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(1..<10, false, expect: "1..<10")
             args(1..<10, true,  expect: "Range(1..<10)")
         }
         
         // ClosedRange
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(1...10, false, expect: "1...10")
             args(1...10, true,  expect: "ClosedRange(1...10)")
         }
@@ -126,22 +126,22 @@ class PrettyTests: XCTestCase {
             let c = C(b: b)
             let d = D(c: c)
             
-            assert(to: pretty.string) {
+            assert(to: describer.string) {
                 args(a, false, expect: #""a""#)
                 args(a, true,  expect: #"A(string: "a")"#)
             }
             
-            assert(to: pretty.string) {
+            assert(to: describer.string) {
                 args(b, false, expect: #"B(a: "a", string: "b")"#)
                 args(b, true,  expect: #"B(a: A(string: "a"), string: "b")"#)
             }
             
-            assert(to: pretty.string) {
+            assert(to: describer.string) {
                 args(c, false, expect: #"C(b: B(a: "a", string: "b"))"#)
                 args(c, true,  expect: #"C(b: B(a: A(string: "a"), string: "b"))"#)
             }
             
-            assert(to: pretty.string) {
+            assert(to: describer.string) {
                 args(d, false, expect: #"D(c: C(b: B(a: "a", string: "b")))"#)
                 args(d, true,  expect: #"D(c: C(b: B(a: A(string: "a"), string: "b")))"#)
             }
@@ -169,13 +169,13 @@ class PrettyTests: XCTestCase {
         let dog = Dog(name: "Pochi", owner: owner, age: nil)
 
         // single
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(owner, false, expect: #"Owner(name: "Nanachi", age: 20, address: "4th layer in Abyss")"#)
             args(owner, true,  expect: #"Owner(name: "Nanachi", age: 20, address: Optional("4th layer in Abyss"))"#)
         }
         
         // nested
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(dog, false, expect: #"Dog(name: "Pochi", owner: Owner(name: "Nanachi", age: 20, address: "4th layer in Abyss"), age: nil)"#)
             args(dog, true,  expect: #"Dog(name: "Pochi", owner: Owner(name: "Nanachi", age: 20, address: Optional("4th layer in Abyss")), age: nil)"#)
         }
@@ -184,7 +184,7 @@ class PrettyTests: XCTestCase {
     func testString_Optional() {
         
         // Optional
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             // .some
             args("Hello" as String?, false, expect: #""Hello""#)
             args("Hello" as String?, true,  expect: #"Optional("Hello")"#)
@@ -229,13 +229,13 @@ class PrettyTests: XCTestCase {
         let dog = Dog(name: "Pochi", owner: owner, age: nil)
         
         // single
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(owner, false, expect: #"Owner(name: "Nanachi", age: 20, address: "4th layer in Abyss")"#)
             args(owner, true,  expect: #"Owner(name: "Nanachi", age: 20, address: Optional("4th layer in Abyss"))"#)
         }
         
         // nested
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(dog, false, expect: #"Dog(name: "Pochi", owner: Owner(name: "Nanachi", age: 20, address: "4th layer in Abyss"), age: nil)"#)
             args(dog, true,  expect: #"Dog(name: "Pochi", owner: Owner(name: "Nanachi", age: 20, address: Optional("4th layer in Abyss")), age: nil)"#)
         }
@@ -249,7 +249,7 @@ class PrettyTests: XCTestCase {
 
         // Note:
         // sorted by string ascending
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(set, false, expect: #"[42, 7]"#)
             args(set, true,  expect: #"Set([Optional(42), Optional(7)])"#)
         }
@@ -263,7 +263,7 @@ class PrettyTests: XCTestCase {
         
         // Note:
         // not sorted unlike `Set`
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(array, false, expect: #"[7, 42]"#)
             args(array, true,  expect: #"[Optional(7), Optional(42)]"#)
         }
@@ -279,7 +279,7 @@ class PrettyTests: XCTestCase {
         ]
 
         // Dictinary
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(dictionary, false, expect: #"[1: "One", 2: "Two"]"#)
             args(dictionary, true,  expect: #"[1: Optional("One"), 2: Optional("Two")]"#)
         }
@@ -295,7 +295,7 @@ class PrettyTests: XCTestCase {
         ]
 
         // Dictionary in Struct
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(dictionaryInStruct, false, expect: #"["mike": Cat(id: "mike", name: "ポチ"), "tama": Cat(id: "tama", name: "タマ")]"#)
             args(dictionaryInStruct, true,  expect: #"["mike": Cat(id: "mike", name: Optional("ポチ")), "tama": Cat(id: "tama", name: Optional("タマ"))]"#)
         }
@@ -307,14 +307,14 @@ class PrettyTests: XCTestCase {
     func testString_Tuple() {
         let tuple = (1, ("one", URL(string: "https://www.example.com/")!))
         
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(tuple, false, expect: #"(1, ("one", https://www.example.com/))"#)
             args(tuple, true,  expect: #"(1, ("one", URL("https://www.example.com/")))"#)
         }
         
         let labeledTuple = (2019, region: "Chili", variety: Optional("Chardonnay"), taste: ["round", "smooth", "young"])
 
-        assert(to: pretty.string) {
+        assert(to: describer.string) {
             args(labeledTuple, false, expect: #"(2019, region: "Chili", variety: "Chardonnay", taste: ["round", "smooth", "young"])"#)
             args(labeledTuple, true,  expect: #"(2019, region: "Chili", variety: Optional("Chardonnay"), taste: ["round", "smooth", "young"])"#)
         }
@@ -330,7 +330,7 @@ class PrettyTests: XCTestCase {
                 case apple = 0
             }
             
-            assert(to: pretty.string) {
+            assert(to: describer.string) {
                 args(Fruit.apple, false, expect: ".apple")
                 args(Fruit.apple, true,  expect: "Fruit.apple")
             }
@@ -344,7 +344,7 @@ class PrettyTests: XCTestCase {
                 case banana(juicy: Bool) // with label
             }
 
-            assert(to: pretty.string) {
+            assert(to: describer.string) {
                 // has one
                 args(Fruit.apple("りんご"), false, expect: #".apple("りんご")"#)
                 args(Fruit.apple("りんご"), true,  expect: #"Fruit.apple("りんご")"#)
@@ -376,7 +376,7 @@ class PrettyTests: XCTestCase {
                 case orange(taste: Taste)
             }
 
-            assert(to: pretty.string) {
+            assert(to: describer.string) {
                 // nested one
                 args(Fruit.apple(.sweet), false, expect: ".apple(.sweet)")
                 args(Fruit.apple(.sweet), true,  expect: "Fruit.apple(Taste.sweet)")
@@ -398,7 +398,7 @@ class PrettyTests: XCTestCase {
             "Two": 2,
         ]
 
-        let result = try pretty.extractKeyValues(from: dictionary) as? [(String, Int)]
+        let result = try describer.extractKeyValues(from: dictionary) as? [(String, Int)]
 
         // Note:
         // XCTUnwrap is not supported Swift Package Manager currently.

--- a/Tests/SwiftPrettyPrintTests/Helper/DebugHelper.swift
+++ b/Tests/SwiftPrettyPrintTests/Helper/DebugHelper.swift
@@ -8,29 +8,29 @@
 import SwiftPrettyPrint
 
 struct DebugHelper {
-    var option: Debug.Option
+    var option: Pretty.Option
 
     func print(label: String? = nil, _ target: Any) -> String {
         var s = ""
-        Debug.print(label: label, target, option: option, to: &s)
+        Pretty.print(label: label, target, option: option, to: &s)
         return s
     }
 
     func printDebug(label: String? = nil, _ target: Any) -> String {
         var s = ""
-        Debug.printDebug(label: label, target, option: option, to: &s)
+        Pretty.printDebug(label: label, target, option: option, to: &s)
         return s
     }
 
     func prettyPrint(label: String? = nil, _ target: Any) -> String {
         var s = ""
-        Debug.prettyPrint(label: label, target, option: option, to: &s)
+        Pretty.prettyPrint(label: label, target, option: option, to: &s)
         return s
     }
 
     func prettyPrintDebug(label: String? = nil, _ target: Any) -> String {
         var s = ""
-        Debug.prettyPrintDebug(label: label, target, option: option, to: &s)
+        Pretty.prettyPrintDebug(label: label, target, option: option, to: &s)
         return s
     }
 }

--- a/Tests/SwiftPrettyPrintTests/Public/DebugTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/DebugTests.swift
@@ -10,7 +10,7 @@ import SwiftPrettyPrint // Note: don't use `@testable`, because test to public A
 import XCTest
 
 class DebugTests: XCTestCase {
-    let helper = DebugHelper(option: Debug.Option(prefix: "[DEBUG]", indentSize: 4))
+    let helper = DebugHelper(option: Pretty.Option(prefix: "[DEBUG]", indentSize: 4))
 
     override func setUp() {}
     override func tearDown() {}
@@ -208,15 +208,15 @@ class DebugTests: XCTestCase {
         //
 
         var result = ""
-        Debug.print(array, 42, to: &result)
+        Pretty.print(array, 42, to: &result)
         XCTAssertEqual(result, #"["Hello", "World"] 42"# + "\n")
 
         result = ""
-        Debug.printDebug(array, 42, to: &result)
+        Pretty.printDebug(array, 42, to: &result)
         XCTAssertEqual(result, #"["Hello", "World"] 42"# + "\n")
 
         result = ""
-        Debug.prettyPrint(array, 42, to: &result)
+        Pretty.prettyPrint(array, 42, to: &result)
         XCTAssertEqual(result, """
             [
                 "Hello",
@@ -226,7 +226,7 @@ class DebugTests: XCTestCase {
             """ + "\n")
 
         result = ""
-        Debug.prettyPrintDebug(array, 42, to: &result)
+        Pretty.prettyPrintDebug(array, 42, to: &result)
         XCTAssertEqual(result, """
             [
                 "Hello",
@@ -240,15 +240,15 @@ class DebugTests: XCTestCase {
         //
 
         result = ""
-        Debug.print(array, 42, separator: "!!", to: &result)
+        Pretty.print(array, 42, separator: "!!", to: &result)
         XCTAssertEqual(result, #"["Hello", "World"]!!42"# + "\n")
 
         result = ""
-        Debug.printDebug(array, 42, separator: "!!", to: &result)
+        Pretty.printDebug(array, 42, separator: "!!", to: &result)
         XCTAssertEqual(result, #"["Hello", "World"]!!42"# + "\n")
 
         result = ""
-        Debug.prettyPrint(array, 42, separator: "!!\n", to: &result)
+        Pretty.prettyPrint(array, 42, separator: "!!\n", to: &result)
         XCTAssertEqual(result, """
             [
                 "Hello",
@@ -258,7 +258,7 @@ class DebugTests: XCTestCase {
             """ + "\n")
 
         result = ""
-        Debug.prettyPrintDebug(array, 42, separator: "!!\n", to: &result)
+        Pretty.prettyPrintDebug(array, 42, separator: "!!\n", to: &result)
         XCTAssertEqual(result, """
             [
                 "Hello",

--- a/Tests/SwiftPrettyPrintTests/Public/OptionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/OptionTests.swift
@@ -9,7 +9,7 @@ import XCTest
 import SwiftPrettyPrint
 
 class OptionTests: XCTestCase {
-    let helper = DebugHelper(option: Debug.Option(prefix: "<DEBUG>", indentSize: 2))
+    let helper = DebugHelper(option: Pretty.Option(prefix: "<DEBUG>", indentSize: 2))
     
     override func setUp() {}
 


### PR DESCRIPTION
The name `Debug` is used in many software projects so which can conflicts.
Therefore renamed to `Pretty` from `Debug`.

## TODO
- [x] change public API
  - [x] `Debug` -> `Pretty`
- [x] change internal API
  - [x] `Pretty` -> `PrettyDescriber`
  - [x] `PrettyError` -> `PrettyDescriberError`
- [x] update Example
- [x] update README