### PR TITLE
feature: combine - some fix and add example

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -5,7 +5,7 @@ use_frameworks!
 #
 # Install from local parent directory.
 #
-pod "SwiftPrettyPrint", :path => "../", :branch => "feature/combine-example", :configuration => "Debug"
+pod "SwiftPrettyPrint", :path => "../", :branch => "master", :configuration => "Debug"
 
 #
 # Typical: install from CocoaPods repository.

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -5,7 +5,7 @@ use_frameworks!
 #
 # Install from local parent directory.
 #
-pod "SwiftPrettyPrint", :path => "../", :configuration => "Debug"
+pod "SwiftPrettyPrint", :path => "../", :branch => "feature/combine-example", :configuration => "Debug"
 
 #
 # Typical: install from CocoaPods repository.

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,16 +1,17 @@
 PODS:
-  - SwiftPrettyPrint (0.0.6)
+  - SwiftPrettyPrint (1.0.0)
 
 DEPENDENCIES:
   - SwiftPrettyPrint (from `../`)
 
 EXTERNAL SOURCES:
   SwiftPrettyPrint:
+    :branch: feature/combine-example
     :path: "../"
 
 SPEC CHECKSUMS:
-  SwiftPrettyPrint: e6282140cfa70aced5a093b9c9a2120b8bf1a057
+  SwiftPrettyPrint: 02010eb68c416300eb9d0d0dccafa82b5856466a
 
-PODFILE CHECKSUM: e57c1331f81ff220ccc169627a83df5238a8e57f
+PODFILE CHECKSUM: a6c823860b984065d3e18d82c62ebf2829151fcd
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.0

--- a/Example/SwiftPrettyPrintExample.xcodeproj/project.pbxproj
+++ b/Example/SwiftPrettyPrintExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		20F00923ACB364A57C37E2C4 /* Pods_SwiftPrettyPrintExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFCD0B73BE04DAE6F974CF97 /* Pods_SwiftPrettyPrintExample.framework */; };
+		7032C8502576113900428353 /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032C84F2576113900428353 /* ContentViewModel.swift */; };
 		E560881423FB6EA2006AB5D0 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = E560881323FB6EA2006AB5D0 /* Debug.swift */; };
 		E560881C23FB707F006AB5D0 /* Dog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E560881B23FB707F006AB5D0 /* Dog.swift */; };
 		E5E842E423FB6B3900391E9F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5E842E323FB6B3900391E9F /* AppDelegate.swift */; };
@@ -34,6 +35,7 @@
 		13713262837E11A7F3C73644 /* Pods-SwiftPrettyPrintExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPrettyPrintExample.release.xcconfig"; path = "Target Support Files/Pods-SwiftPrettyPrintExample/Pods-SwiftPrettyPrintExample.release.xcconfig"; sourceTree = "<group>"; };
 		3B3B027DA6D075BA3D67CED7 /* Pods_SwiftPrettyPrintExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftPrettyPrintExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		487D9DEBB0BCBEBDF923F3A4 /* Pods-SwiftPrettyPrintExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPrettyPrintExampleTests.release.xcconfig"; path = "Target Support Files/Pods-SwiftPrettyPrintExampleTests/Pods-SwiftPrettyPrintExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		7032C84F2576113900428353 /* ContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
 		825B48CD5C133ED74B872617 /* Pods-SwiftPrettyPrintExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPrettyPrintExample.debug.xcconfig"; path = "Target Support Files/Pods-SwiftPrettyPrintExample/Pods-SwiftPrettyPrintExample.debug.xcconfig"; sourceTree = "<group>"; };
 		A8B066E3D7B5E0CBBFE5D278 /* Pods-SwiftPrettyPrintExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPrettyPrintExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-SwiftPrettyPrintExampleTests/Pods-SwiftPrettyPrintExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		AFCD0B73BE04DAE6F974CF97 /* Pods_SwiftPrettyPrintExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftPrettyPrintExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -100,6 +102,7 @@
 				E5E842E323FB6B3900391E9F /* AppDelegate.swift */,
 				E5E842E523FB6B3900391E9F /* SceneDelegate.swift */,
 				E5E842E723FB6B3900391E9F /* ContentView.swift */,
+				7032C84F2576113900428353 /* ContentViewModel.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -331,6 +334,7 @@
 			files = (
 				E5E842E423FB6B3900391E9F /* AppDelegate.swift in Sources */,
 				E560881423FB6EA2006AB5D0 /* Debug.swift in Sources */,
+				7032C8502576113900428353 /* ContentViewModel.swift in Sources */,
 				E5E842E623FB6B3900391E9F /* SceneDelegate.swift in Sources */,
 				E560881C23FB707F006AB5D0 /* Dog.swift in Sources */,
 				E5E842E823FB6B3900391E9F /* ContentView.swift in Sources */,

--- a/Example/SwiftPrettyPrintExample/Source/ContentView.swift
+++ b/Example/SwiftPrettyPrintExample/Source/ContentView.swift
@@ -9,6 +9,8 @@
 import SwiftUI
 
 struct ContentView: View {
+    @ObservedObject var viewModel = ContentViewModel()
+
     var body: some View {
         Text("Hello, World!")
     }

--- a/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
+++ b/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  ContentViewModel.swift
+//  SwiftPrettyPrintExample
+//
+//  Created by Yusuke Hosonuma on 2020/12/01.
+//  Copyright © 2020 Yusuke Hosonuma. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+final class ContentViewModel: ObservableObject {
+    var cancellables: [AnyCancellable] = []
+
+    init() {
+        let array = [
+            Dog(id: DogId(rawValue: "pochi"), price: Price(rawValue: 10.0), name: "ポチ"),
+            Dog(id: DogId(rawValue: "koro"), price: Price(rawValue: 20.0), name: "コロ"),
+        ]
+
+        array
+            .publisher
+            .prettyPrint("🍌", when: [.output, .completion], format: .multiline)
+            .sink { _ in }
+            .store(in: &cancellables)
+
+        // =>
+        // 🍌: receive value:
+        // Dog(
+        //     id: "pochi",
+        //     price: 10.0,
+        //     name: "ポチ"
+        // )
+        // 🍌: receive value:
+        // Dog(
+        //     id: "koro",
+        //     price: 20.0,
+        //     name: "コロ"
+        // )
+        // 🍌: receive finished
+    }
+}

--- a/Sources/Public/CombineExtension.swift
+++ b/Sources/Public/CombineExtension.swift
@@ -44,6 +44,9 @@
                 Swift.print(message, terminator: terminator, to: &out)
             }
 
+            var option = Pretty.sharedOption
+            option.prefix = nil // Ignore sharedOption's `prefix.
+
             return handleEvents(receiveSubscription: {
                 _print("receive subscription: \($0)", type: .subscription)
             }, receiveOutput: {
@@ -51,13 +54,13 @@
                 case .singleline:
                     var s: String = ""
                     Swift.print("receive value: ", terminator: "", to: &s)
-                    Pretty.print($0, to: &s)
+                    Pretty.print($0, option: option, to: &s)
                     _print(s, type: .output, terminator: "")
 
                 case .multiline:
                     var s: String = ""
                     Swift.print("receive value:", to: &s)
-                    Pretty.prettyPrint($0, to: &s)
+                    Pretty.prettyPrint($0, option: option, to: &s)
                     _print(s, type: .output, terminator: "")
                 }
             }, receiveCompletion: {

--- a/Sources/Public/CombineExtension.swift
+++ b/Sources/Public/CombineExtension.swift
@@ -45,7 +45,7 @@
             }
 
             var option = Pretty.sharedOption
-            option.prefix = nil // Ignore sharedOption's `prefix.
+            option.prefix = nil // Prepend duplicat output.
 
             return handleEvents(receiveSubscription: {
                 _print("receive subscription: \($0)", type: .subscription)

--- a/Sources/Public/CombineExtension.swift
+++ b/Sources/Public/CombineExtension.swift
@@ -45,7 +45,7 @@
             }
 
             var option = Pretty.sharedOption
-            option.prefix = nil // Prepend duplicat output.
+            option.prefix = nil // prevent duplicate output.
 
             return handleEvents(receiveSubscription: {
                 _print("receive subscription: \($0)", type: .subscription)

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -104,7 +104,7 @@ final class CombineExtensionTests: XCTestCase {
             
             array
                 .publisher
-                .prettyPrint(when: test.when, format: .multiline, to: recorder)
+                .prettyPrint(when: test.when, format: .singleline, to: recorder)
                 .handleEvents(receiveCompletion: { _ in
                     exp.fulfill()
                 })

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -104,7 +104,7 @@ final class CombineExtensionTests: XCTestCase {
             
             array
                 .publisher
-                .prettyPrint(when: test.when, format: .singleline, to: recorder)
+                .prettyPrint(when: test.when, format: .multiline, to: recorder)
                 .handleEvents(receiveCompletion: { _ in
                     exp.fulfill()
                 })


### PR DESCRIPTION
ref: #119 

- [x] Fix
  - [x] Add overloaded function that `to:` argument is omitted.
  - [x] Ignore `prefix` option of `Pretty.sharedOption` in `prettyPrint` operator.
- [x] Add example