### PR TITLE
Support pretty-print for errors in failures and refactor UnitTest on Combine 

### DIFF
--- a/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
+++ b/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
@@ -13,12 +13,11 @@ final class ContentViewModel: ObservableObject {
     var cancellables: [AnyCancellable] = []
 
     init() {
-        let array = [
-            Dog(id: DogId(rawValue: "pochi"), price: Price(rawValue: 10.0), name: "ポチ"),
-            Dog(id: DogId(rawValue: "koro"), price: Price(rawValue: 20.0), name: "コロ"),
-        ]
+        let dog1 = Dog(id: DogId(rawValue: "pochi"), price: Price(rawValue: 10.0), name: "ポチ")
+        let dog2 = Dog(id: DogId(rawValue: "koro"), price: Price(rawValue: 20.0), name: "コロ")
+        let successArray = [dog1, dog2]
 
-        array
+        successArray
             .publisher
             .prettyPrint("🍌", when: [.output, .completion], format: .multiline)
             .sink { _ in }

--- a/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
+++ b/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
@@ -32,15 +32,29 @@ final class ContentViewModel: ObservableObject {
         // 🐕: receive finished
 
         let subject = PassthroughSubject<Dog, DogsError>()
-        let publisher = subject.eraseToAnyPublisher()
 
-        publisher
-            .prettyPrint("🐶", when: [.output, .completion], format: .multiline)
+        subject
+            .eraseToAnyPublisher()
+            .prettyPrint("🐩", format: .multiline)
             .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
             .store(in: &cancellables)
 
-        subject.send(dog1)
         subject.send(dog2)
         subject.send(completion: .failure(DogsError()))
+
+        // =>
+        // 🐩: request unlimited
+        // 🐩: receive subscription: PassthroughSubject
+        // 🐩: receive value:
+        // Dog(
+        //     id: "koro",
+        //     price: 20.0,
+        //     name: "コロ"
+        // )
+        // 🐩: receive failure:
+        // DogsError(
+        //     code: 101,
+        //     message: "dogs have run away"
+        // )
     }
 }

--- a/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
+++ b/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
@@ -15,28 +15,21 @@ final class ContentViewModel: ObservableObject {
     init() {
         let dog1 = Dog(id: DogId(rawValue: "pochi"), price: Price(rawValue: 10.0), name: "ポチ")
         let dog2 = Dog(id: DogId(rawValue: "koro"), price: Price(rawValue: 20.0), name: "コロ")
-        let successArray = [dog1, dog2]
 
-        successArray
+        [dog1]
             .publisher
-            .prettyPrint("🍌", when: [.output, .completion], format: .multiline)
+            .prettyPrint("🐕", when: [.output, .completion], format: .multiline)
             .sink { _ in }
             .store(in: &cancellables)
 
         // =>
-        // 🍌: receive value:
+        // 🐕: receive value:
         // Dog(
         //     id: "pochi",
         //     price: 10.0,
         //     name: "ポチ"
         // )
-        // 🍌: receive value:
-        // Dog(
-        //     id: "koro",
-        //     price: 20.0,
-        //     name: "コロ"
-        // )
-        // 🍌: receive finished
+        // 🐕: receive finished
 
         let subject = PassthroughSubject<Dog, DogsError>()
         let publisher = subject.eraseToAnyPublisher()

--- a/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
+++ b/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
@@ -37,5 +37,17 @@ final class ContentViewModel: ObservableObject {
         //     name: "コロ"
         // )
         // 🍌: receive finished
+
+        let subject = PassthroughSubject<Dog, DogsError>()
+        let publisher = subject.eraseToAnyPublisher()
+
+        publisher
+            .prettyPrint("🐶", when: [.output, .completion], format: .multiline)
+            .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+            .store(in: &cancellables)
+
+        subject.send(dog1)
+        subject.send(dog2)
+        subject.send(completion: .failure(DogsError()))
     }
 }

--- a/Example/SwiftPrettyPrintExample/Source/Dog.swift
+++ b/Example/SwiftPrettyPrintExample/Source/Dog.swift
@@ -14,3 +14,8 @@ struct Dog {
 
 struct DogId { var rawValue: String }
 struct Price { var rawValue: Double }
+
+struct DogsError: Error {
+    let code: Int = 101
+    let message: String = "dogs have run away"
+}

--- a/Sources/Public/CombineExtension.swift
+++ b/Sources/Public/CombineExtension.swift
@@ -63,8 +63,26 @@
                     Pretty.prettyPrint($0, option: option, to: &s)
                     _print(s, type: .output, terminator: "")
                 }
-            }, receiveCompletion: {
-                _print("receive \($0)", type: .completion)
+            }, receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    _print("receive finished", type: .completion)
+                case let .failure(error):
+                    switch format {
+                    case .singleline:
+                        var s: String = ""
+                        Swift.print("receive failure: ", terminator: "", to: &s)
+                        Pretty.print(error, option: option, to: &s)
+                        _print(s, type: .output, terminator: "")
+
+                    case .multiline:
+                        var s: String = ""
+                        Swift.print("receive failure:", to: &s)
+                        Pretty.prettyPrint(error, option: option, to: &s)
+                        _print(s, type: .output, terminator: "")
+                    }
+                }
+
             }, receiveCancel: {
                 _print("cancel", type: .cancel)
             }, receiveRequest: {

--- a/Sources/Public/CombineExtension.swift
+++ b/Sources/Public/CombineExtension.swift
@@ -44,45 +44,35 @@
                 Swift.print(message, terminator: terminator, to: &out)
             }
 
+            func _prettyPrint(value: Any, label: String, type: CombineOperatorOption.Event) {
+                var s: String = ""
+                switch format {
+                case .singleline:
+                    Swift.print("receive \(label): ", terminator: "", to: &s)
+                    Pretty.print(value, option: option, to: &s)
+                    _print(s, type: type, terminator: "")
+
+                case .multiline:
+                    Swift.print("receive \(label):", to: &s)
+                    Pretty.prettyPrint(value, option: option, to: &s)
+                    _print(s, type: type, terminator: "")
+                }
+            }
+
             var option = Pretty.sharedOption
             option.prefix = nil // prevent duplicate output.
 
             return handleEvents(receiveSubscription: {
                 _print("receive subscription: \($0)", type: .subscription)
             }, receiveOutput: {
-                switch format {
-                case .singleline:
-                    var s: String = ""
-                    Swift.print("receive value: ", terminator: "", to: &s)
-                    Pretty.print($0, option: option, to: &s)
-                    _print(s, type: .output, terminator: "")
-
-                case .multiline:
-                    var s: String = ""
-                    Swift.print("receive value:", to: &s)
-                    Pretty.prettyPrint($0, option: option, to: &s)
-                    _print(s, type: .output, terminator: "")
-                }
+                _prettyPrint(value: $0, label: "value", type: .output)
             }, receiveCompletion: { completion in
                 switch completion {
                 case .finished:
                     _print("receive finished", type: .completion)
                 case let .failure(error):
-                    switch format {
-                    case .singleline:
-                        var s: String = ""
-                        Swift.print("receive failure: ", terminator: "", to: &s)
-                        Pretty.print(error, option: option, to: &s)
-                        _print(s, type: .output, terminator: "")
-
-                    case .multiline:
-                        var s: String = ""
-                        Swift.print("receive failure:", to: &s)
-                        Pretty.prettyPrint(error, option: option, to: &s)
-                        _print(s, type: .output, terminator: "")
-                    }
+                    _prettyPrint(value: error, label: "failure", type: .completion)
                 }
-
             }, receiveCancel: {
                 _print("cancel", type: .cancel)
             }, receiveRequest: {

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -70,6 +70,22 @@ final class CombineExtensionTests: XCTestCase {
             🍎: receive value: [3, 4]
             🍎: receive finished
             """)
+        
+        let exp2 = expectation(description: "")
+        
+        Fail<[Int], TestError>(error: TestError())
+            .prettyPrint("🍎", when: [.completion], format: .singleline, to: recorder)
+            .handleEvents(receiveCompletion: { _ in
+                exp2.fulfill()
+            })
+            .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+            .store(in: &cancellables)
+        wait(for: [exp2], timeout: 3)
+        
+        XCTAssert(recorder.contents.contains("🍎: receive failure: TestError(code: 1, message: \"This is the error\")"))
+        
+        
+        
     }
     
     func testWhen() throws {

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -215,6 +215,18 @@ final class CombineExtensionTests: XCTestCase {
             receive value: [3, 4]
             receive finished
             """)
+        
+        let exp2 = expectation(description: "")
+        Fail<[Int], TestError>(error: TestError())
+            .prettyPrint(when: [.completion], format: .singleline, to: recorder)
+            .handleEvents(receiveCompletion: { _ in
+                exp2.fulfill()
+            })
+            .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+            .store(in: &cancellables)
+        wait(for: [exp2], timeout: 3)
+        
+        XCTAssert(recorder.contents.contains("receive failure: TestError(code: 1, message: \"This is the error\")"))
     }
 
     func testMultiline() throws {

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -259,14 +259,14 @@ final class CombineExtensionTests: XCTestCase {
             """)
     }
     
-    private func subscribeAndWait(_ publisher: AnyPublisher<[Int], TestError>, exp: XCTestExpectation) {
+    private func subscribeAndWait(_ publisher: AnyPublisher<[Int], TestError>, sendHandler: (() -> Void)? = nil, exp: XCTestExpectation) {
         publisher
             .handleEvents(receiveCompletion: { _ in
                 exp.fulfill()
             })
             .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
             .store(in: &cancellables)
-        
+        sendHandler?()
         wait(for: [exp], timeout: 3)
     }
 }

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -203,17 +203,18 @@ final class CombineExtensionTests: XCTestCase {
     }
 
     func testMultiline() throws {
-        let recorder = StringRecorder()
-        
-        subscribeAndWait(
-            array.publisher.setFailureType(to: TestError.self).prettyPrint(to: recorder).eraseToAnyPublisher()
-        )
-        // Note:
-        // Order of first and second line is unstable.
-        XCTAssert(recorder.contents.contains("receive subscription: [[1, 2], [3, 4]]"))
-        XCTAssert(recorder.contents.contains("request unlimited"))
-        assertEqualLines(recorder.contents.split(separator: "\n")[2...].joined(separator: "\n"),
-            """
+        do {
+            let recorder = StringRecorder()
+            
+            subscribeAndWait(
+                array.publisher.setFailureType(to: TestError.self).prettyPrint(to: recorder).eraseToAnyPublisher()
+            )
+            // Note:
+            // Order of first and second line is unstable.
+            XCTAssert(recorder.contents.contains("receive subscription: [[1, 2], [3, 4]]"))
+            XCTAssert(recorder.contents.contains("request unlimited"))
+            assertEqualLines(recorder.contents.split(separator: "\n")[2...].joined(separator: "\n"),
+                             """
             receive value:
             [
                 1,
@@ -226,21 +227,24 @@ final class CombineExtensionTests: XCTestCase {
             ]
             receive finished
             """)
+        }
         
-        let recorder2 = StringRecorder()
-        
-        subscribeAndWait(
-            Fail<[Int], TestError>(error: TestError()).prettyPrint(to: recorder2).eraseToAnyPublisher()
-        )
-        
-        assertEqualLines(recorder2.contents.split(separator: "\n")[2...].joined(separator: "\n"),
-            """
+        do {
+            let recorder = StringRecorder()
+            
+            subscribeAndWait(
+                Fail<[Int], TestError>(error: TestError()).prettyPrint(to: recorder).eraseToAnyPublisher()
+            )
+            
+            assertEqualLines(recorder.contents.split(separator: "\n")[2...].joined(separator: "\n"),
+                             """
             receive failure:
             TestError(
                 code: 1,
                 message: "This is the error"
             )
             """)
+        }
     }
     
     private func subscribeAndWait(_ publisher: AnyPublisher<[Int], TestError>, sendHandler: (() -> Void)? = nil) {

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -277,7 +277,7 @@ final class CombineExtensionTests: XCTestCase {
         
         assertEqualLines(recorder2.contents.split(separator: "\n")[2...].joined(separator: "\n"),
             """
-            receive value:
+            receive failure:
             TestError(
                 code: 1,
                 message: "This is the error"

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -286,6 +286,17 @@ final class CombineExtensionTests: XCTestCase {
             )
             """)
     }
+    
+    private func subscribeAndWait(_ publisher: AnyPublisher<[Int], TestError>, exp: XCTestExpectation) {
+        publisher
+            .handleEvents(receiveCompletion: { _ in
+                exp.fulfill()
+            })
+            .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+            .store(in: &cancellables)
+        
+        wait(for: [exp], timeout: 3)
+    }
 }
 
 #endif

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -206,12 +206,12 @@ final class CombineExtensionTests: XCTestCase {
         let recorder2 = StringRecorder()
         subscribeAndWait(
             Fail<[Int], TestError>(error: TestError())
-            .prettyPrint(format: .singleline, to: recorder2)
+                .prettyPrint(format: .singleline, to: recorder2)
                 .eraseToAnyPublisher(),
             exp: exp2
         )
 
-        XCTAssert(recorder.contents.contains("receive failure: TestError(code: 1, message: \"This is the error\")"))
+        XCTAssert(recorder2.contents.contains("receive failure: TestError(code: 1, message: \"This is the error\")"))
     }
 
     func testMultiline() throws {

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -170,36 +170,38 @@ final class CombineExtensionTests: XCTestCase {
     }
     
     func testSingleline() throws {
-        
-        let recorder = StringRecorder()
-        
-        
-        subscribeAndWait(
-            array.publisher
-                .setFailureType(to: TestError.self)
-                .prettyPrint(format: .singleline, to: recorder)
-                .eraseToAnyPublisher()
-        )
-        
-        // Note:
-        // Order of first and second line is unstable.
-        XCTAssert(recorder.contents.contains("receive subscription: [[1, 2], [3, 4]]"))
-        XCTAssert(recorder.contents.contains("request unlimited"))
-        assertEqualLines(recorder.contents.split(separator: "\n")[2...].joined(separator: "\n"),
-            """
+        do {
+            let recorder = StringRecorder()
+            
+            subscribeAndWait(
+                array.publisher
+                    .setFailureType(to: TestError.self)
+                    .prettyPrint(format: .singleline, to: recorder)
+                    .eraseToAnyPublisher()
+            )
+            
+            // Note:
+            // Order of first and second line is unstable.
+            XCTAssert(recorder.contents.contains("receive subscription: [[1, 2], [3, 4]]"))
+            XCTAssert(recorder.contents.contains("request unlimited"))
+            assertEqualLines(recorder.contents.split(separator: "\n")[2...].joined(separator: "\n"),
+                             """
             receive value: [1, 2]
             receive value: [3, 4]
             receive finished
             """)
+        }
         
-        let recorder2 = StringRecorder()
-        subscribeAndWait(
-            Fail<[Int], TestError>(error: TestError())
-                .prettyPrint(format: .singleline, to: recorder2)
-                .eraseToAnyPublisher()
-        )
-
-        XCTAssert(recorder2.contents.contains("receive failure: TestError(code: 1, message: \"This is the error\")"))
+        do {
+            let recorder = StringRecorder()
+            subscribeAndWait(
+                Fail<[Int], TestError>(error: TestError())
+                    .prettyPrint(format: .singleline, to: recorder)
+                    .eraseToAnyPublisher()
+            )
+            
+            XCTAssert(recorder.contents.contains("receive failure: TestError(code: 1, message: \"This is the error\")"))
+        }
     }
 
     func testMultiline() throws {

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -236,21 +236,10 @@ final class CombineExtensionTests: XCTestCase {
         let recorder = StringRecorder()
         let exp = expectation(description: "")
         
-        func _subscribe(_ publisher: AnyPublisher<[Int], TestError>, recorder: StringRecorder, exp: XCTestExpectation) {
-                publisher
-                    .prettyPrint(to: recorder)
-                .handleEvents(receiveCompletion: { _ in
-                    exp.fulfill()
-                })
-                .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
-                .store(in: &cancellables)
-            
-            wait(for: [exp], timeout: 3)
-        }
-        
-        _subscribe(array.publisher.setFailureType(to: TestError.self).eraseToAnyPublisher(),
-                   recorder: recorder,
-                   exp: exp)
+        subscribeAndWait(
+            array.publisher.setFailureType(to: TestError.self).prettyPrint(to: recorder).eraseToAnyPublisher(),
+            exp: exp
+        )
         // Note:
         // Order of first and second line is unstable.
         XCTAssert(recorder.contents.contains("receive subscription: [[1, 2], [3, 4]]"))
@@ -273,9 +262,10 @@ final class CombineExtensionTests: XCTestCase {
         let recorder2 = StringRecorder()
         let exp2 = expectation(description: "")
         
-        _subscribe(Fail<[Int], TestError>(error: TestError()).eraseToAnyPublisher(),
-                   recorder: recorder2,
-                   exp: exp2)
+        subscribeAndWait(
+            Fail<[Int], TestError>(error: TestError()).prettyPrint(to: recorder2).eraseToAnyPublisher(),
+            exp: exp2
+        )
         
         assertEqualLines(recorder2.contents.split(separator: "\n")[2...].joined(separator: "\n"),
             """

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -156,8 +156,9 @@ final class CombineExtensionTests: XCTestCase {
             let subject: PassthroughSubject<[Int], TestError> = .init()
             let recorder = StringRecorder()
             subscribeAndWait(
-                subject.prettyPrint(when: test.when,
-                                    format: .singleline,to: recorder).eraseToAnyPublisher(),
+                subject
+                    .prettyPrint(when: test.when, format: .singleline, to: recorder)
+                    .eraseToAnyPublisher(),
                 sendHandler: { [array] in
                     subject.send(array[0])
                     subject.send(array[1])

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -47,14 +47,12 @@ final class CombineExtensionTests: XCTestCase {
     
     func testPrefix() throws {
         let recorder = StringRecorder()
-        let exp = expectation(description: "")
         
         subscribeAndWait(
             array
                 .publisher
                 .setFailureType(to: TestError.self)
-                .prettyPrint("🍎", format: .singleline, to: recorder).eraseToAnyPublisher(),
-            exp: exp
+                .prettyPrint("🍎", format: .singleline, to: recorder).eraseToAnyPublisher()
         )
         
         // Note:
@@ -68,12 +66,9 @@ final class CombineExtensionTests: XCTestCase {
             🍎: receive finished
             """)
         
-        let exp2 = expectation(description: "")
-        
         subscribeAndWait(
             Fail<[Int], TestError>(error: TestError())
-                .prettyPrint("🍎", when: [.completion], format: .singleline, to: recorder).eraseToAnyPublisher(),
-            exp: exp2
+                .prettyPrint("🍎", when: [.completion], format: .singleline, to: recorder).eraseToAnyPublisher()
         )
         
         XCTAssert(recorder.contents.contains("🍎: receive failure: TestError(code: 1, message: \"This is the error\")"))
@@ -115,13 +110,11 @@ final class CombineExtensionTests: XCTestCase {
         
         for test in tests {
             let recorder = StringRecorder()
-            let exp = expectation(description: "")
             
             subscribeAndWait(
                 array.publisher
                     .setFailureType(to: TestError.self)
-                    .prettyPrint(when: test.when, format: .singleline, to: recorder).eraseToAnyPublisher(),
-                exp: exp
+                    .prettyPrint(when: test.when, format: .singleline, to: recorder).eraseToAnyPublisher()
             )
 
             assertEqualLines(recorder.contents, test.expected, line: test.line)
@@ -162,7 +155,6 @@ final class CombineExtensionTests: XCTestCase {
         for test in tests {
             let subject: PassthroughSubject<[Int], TestError> = .init()
             let recorder = StringRecorder()
-            let exp = expectation(description: "")
             subscribeAndWait(
                 subject.prettyPrint(when: test.when,
                                     format: .singleline,to: recorder).eraseToAnyPublisher(),
@@ -170,8 +162,7 @@ final class CombineExtensionTests: XCTestCase {
                     subject.send(array[0])
                     subject.send(array[1])
                     subject.send(completion: .failure(TestError()))
-                },
-                exp: exp
+                }
             )
             
             assertEqualLines(recorder.contents, test.expected, line: test.line)
@@ -181,15 +172,13 @@ final class CombineExtensionTests: XCTestCase {
     func testSingleline() throws {
         
         let recorder = StringRecorder()
-        let exp = expectation(description: "")
         
         
         subscribeAndWait(
             array.publisher
                 .setFailureType(to: TestError.self)
                 .prettyPrint(format: .singleline, to: recorder)
-                .eraseToAnyPublisher(),
-            exp: exp
+                .eraseToAnyPublisher()
         )
         
         // Note:
@@ -203,13 +192,11 @@ final class CombineExtensionTests: XCTestCase {
             receive finished
             """)
         
-        let exp2 = expectation(description: "")
         let recorder2 = StringRecorder()
         subscribeAndWait(
             Fail<[Int], TestError>(error: TestError())
                 .prettyPrint(format: .singleline, to: recorder2)
-                .eraseToAnyPublisher(),
-            exp: exp2
+                .eraseToAnyPublisher()
         )
 
         XCTAssert(recorder2.contents.contains("receive failure: TestError(code: 1, message: \"This is the error\")"))
@@ -217,11 +204,9 @@ final class CombineExtensionTests: XCTestCase {
 
     func testMultiline() throws {
         let recorder = StringRecorder()
-        let exp = expectation(description: "")
         
         subscribeAndWait(
-            array.publisher.setFailureType(to: TestError.self).prettyPrint(to: recorder).eraseToAnyPublisher(),
-            exp: exp
+            array.publisher.setFailureType(to: TestError.self).prettyPrint(to: recorder).eraseToAnyPublisher()
         )
         // Note:
         // Order of first and second line is unstable.
@@ -243,11 +228,9 @@ final class CombineExtensionTests: XCTestCase {
             """)
         
         let recorder2 = StringRecorder()
-        let exp2 = expectation(description: "")
         
         subscribeAndWait(
-            Fail<[Int], TestError>(error: TestError()).prettyPrint(to: recorder2).eraseToAnyPublisher(),
-            exp: exp2
+            Fail<[Int], TestError>(error: TestError()).prettyPrint(to: recorder2).eraseToAnyPublisher()
         )
         
         assertEqualLines(recorder2.contents.split(separator: "\n")[2...].joined(separator: "\n"),
@@ -260,7 +243,8 @@ final class CombineExtensionTests: XCTestCase {
             """)
     }
     
-    private func subscribeAndWait(_ publisher: AnyPublisher<[Int], TestError>, sendHandler: (() -> Void)? = nil, exp: XCTestExpectation) {
+    private func subscribeAndWait(_ publisher: AnyPublisher<[Int], TestError>, sendHandler: (() -> Void)? = nil) {
+        let exp = expectation(description: "")
         publisher
             .handleEvents(receiveCompletion: { _ in
                 exp.fulfill()

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -52,7 +52,8 @@ final class CombineExtensionTests: XCTestCase {
             array
                 .publisher
                 .setFailureType(to: TestError.self)
-                .prettyPrint("🍎", format: .singleline, to: recorder).eraseToAnyPublisher()
+                .prettyPrint("🍎", format: .singleline, to: recorder)
+                .eraseToAnyPublisher()
         )
         
         // Note:
@@ -68,7 +69,8 @@ final class CombineExtensionTests: XCTestCase {
         
         subscribeAndWait(
             Fail<[Int], TestError>(error: TestError())
-                .prettyPrint("🍎", when: [.completion], format: .singleline, to: recorder).eraseToAnyPublisher()
+                .prettyPrint("🍎", when: [.completion], format: .singleline, to: recorder)
+                .eraseToAnyPublisher()
         )
         
         XCTAssert(recorder.contents.contains("🍎: receive failure: TestError(code: 1, message: \"This is the error\")"))
@@ -114,7 +116,8 @@ final class CombineExtensionTests: XCTestCase {
             subscribeAndWait(
                 array.publisher
                     .setFailureType(to: TestError.self)
-                    .prettyPrint(when: test.when, format: .singleline, to: recorder).eraseToAnyPublisher()
+                    .prettyPrint(when: test.when, format: .singleline, to: recorder)
+                    .eraseToAnyPublisher()
             )
 
             assertEqualLines(recorder.contents, test.expected, line: test.line)
@@ -210,7 +213,9 @@ final class CombineExtensionTests: XCTestCase {
             let recorder = StringRecorder()
             
             subscribeAndWait(
-                array.publisher.setFailureType(to: TestError.self).prettyPrint(to: recorder).eraseToAnyPublisher()
+                array.publisher.setFailureType(to: TestError.self)
+                    .prettyPrint(to: recorder)
+                    .eraseToAnyPublisher()
             )
             // Note:
             // Order of first and second line is unstable.
@@ -236,7 +241,9 @@ final class CombineExtensionTests: XCTestCase {
             let recorder = StringRecorder()
             
             subscribeAndWait(
-                Fail<[Int], TestError>(error: TestError()).prettyPrint(to: recorder).eraseToAnyPublisher()
+                Fail<[Int], TestError>(error: TestError())
+                    .prettyPrint(to: recorder)
+                    .eraseToAnyPublisher()
             )
             
             assertEqualLines(recorder.contents.split(separator: "\n")[2...].joined(separator: "\n"),

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -262,6 +262,27 @@ final class CombineExtensionTests: XCTestCase {
             ]
             receive finished
             """)
+        
+        let recorder2 = StringRecorder()
+        let exp2 = expectation(description: "")
+        
+        Fail<[Int], TestError>(error: TestError())
+            .prettyPrint(to: recorder2)
+            .handleEvents(receiveCompletion: { _ in
+                exp2.fulfill()
+            })
+            .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
+            .store(in: &cancellables)
+        wait(for: [exp2], timeout: 3)
+        
+        assertEqualLines(recorder2.contents.split(separator: "\n")[2...].joined(separator: "\n"),
+            """
+            receive value:
+            TestError(
+                code: 1,
+                message: "This is the error"
+            )
+            """)
     }
 }
 

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -32,6 +32,11 @@ final class StringRecorder: TextOutputStream {
     }
 }
 
+struct TestError: Error {
+    let code = 1
+    let message =  "This is the error"
+}
+
 final class CombineExtensionTests: XCTestCase {
     var cancellables: [AnyCancellable] = []
     

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -88,7 +88,7 @@ final class CombineExtensionTests: XCTestCase {
         
     }
     
-    func testWhen() throws {
+    func testWhenForFinished() throws {
         let tests: [(line: UInt, when: [CombineOperatorOption.Event], expected: String)] = [
             (
                 line: #line,

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -163,15 +163,16 @@ final class CombineExtensionTests: XCTestCase {
             let subject: PassthroughSubject<[Int], TestError> = .init()
             let recorder = StringRecorder()
             let exp = expectation(description: "")
-            
             subscribeAndWait(
-                subject.prettyPrint(when: test.when, format: .singleline, to: recorder).eraseToAnyPublisher(),
+                subject.prettyPrint(when: test.when,
+                                    format: .singleline,to: recorder).eraseToAnyPublisher(),
+                sendHandler: { [array] in
+                    subject.send(array[0])
+                    subject.send(array[1])
+                    subject.send(completion: .failure(TestError()))
+                },
                 exp: exp
             )
-            
-            subject.send(array[0])
-            subject.send(array[1])
-            subject.send(completion: .failure(TestError()))
             
             assertEqualLines(recorder.contents, test.expected, line: test.line)
         }

--- a/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
+++ b/Tests/SwiftPrettyPrintTests/Public/CombineExtensionTests.swift
@@ -192,25 +192,17 @@ final class CombineExtensionTests: XCTestCase {
     
     func testSingleline() throws {
         
-        func _subscribe(_ publisher: AnyPublisher<[Int], TestError>, recorder: StringRecorder, exp: XCTestExpectation) {
-                publisher
-                    .prettyPrint(format: .singleline, to: recorder)
-                .handleEvents(receiveCompletion: { _ in
-                    exp.fulfill()
-                })
-                .sink(receiveCompletion: { _ in }, receiveValue: { _ in })
-                .store(in: &cancellables)
-            
-            wait(for: [exp], timeout: 3)
-        }
-        
         let recorder = StringRecorder()
         let exp = expectation(description: "")
         
         
-        _subscribe(array.publisher.setFailureType(to: TestError.self).eraseToAnyPublisher(),
-                   recorder: recorder,
-                   exp: exp)
+        subscribeAndWait(
+            array.publisher
+                .setFailureType(to: TestError.self)
+                .prettyPrint(format: .singleline, to: recorder)
+                .eraseToAnyPublisher(),
+            exp: exp
+        )
         
         // Note:
         // Order of first and second line is unstable.
@@ -225,10 +217,13 @@ final class CombineExtensionTests: XCTestCase {
         
         let exp2 = expectation(description: "")
         let recorder2 = StringRecorder()
-        _subscribe(Fail<[Int], TestError>(error: TestError()).eraseToAnyPublisher(),
-                   recorder: recorder2,
-                   exp: exp2)
-        
+        subscribeAndWait(
+            Fail<[Int], TestError>(error: TestError())
+            .prettyPrint(format: .singleline, to: recorder2)
+                .eraseToAnyPublisher(),
+            exp: exp2
+        )
+
         XCTAssert(recorder.contents.contains("receive failure: TestError(code: 1, message: \"This is the error\")"))
     }
 


### PR DESCRIPTION
# As is 
It seems not supporting to `prettyprint` for errors on Combine.
The following is taken when specifing format as .multiline.
<img width="250" alt="Screen Shot 2020-12-09 at 16 37 34" src="https://user-images.githubusercontent.com/14083051/101599012-5e54da00-3a3c-11eb-8970-8ce8b03f81ad.png">

# To be
Developers can see errors just like values.

### with `.multiline`
<img width="250" alt="Screen Shot 2020-12-09 at 16 37 34" src="https://user-images.githubusercontent.com/14083051/101599285-dcb17c00-3a3c-11eb-9b01-c0a2b661bf6b.png">

### with `.singleline`
<img width="250" alt="Screen Shot 2020-12-09 at 16 39 11" src="https://user-images.githubusercontent.com/14083051/101599438-1bdfcd00-3a3d-11eb-9b2e-a52084b2c04c.png">


