### PR TITLE
add prettyPrint Command for LLDB with regex

### DIFF
--- a/.lldbinit
+++ b/.lldbinit
@@ -1,2 +1,3 @@
+command regex _p  's/(.+)/e -l swift -o -- Pretty.print(%1)/'
 command regex _pp 's/(.+)/e -l swift -o -- Pretty.prettyPrint(%1)/'
-command regex _p 's/(.+)/e - l swift -o -- Pretty.print(%1)/'
+

--- a/.lldbinit
+++ b/.lldbinit
@@ -1,0 +1,2 @@
+command regex _pp 's/(.+)/e -l swift -o -- Pretty.prettyPrint(%1)/'
+command regex _p 's/(.+)/e - l swift -o -- Pretty.print(%1)/'

--- a/README.md
+++ b/README.md
@@ -368,6 +368,26 @@ let package = Package(
 
 Alternatively, use Xcode integration. This function is available since Xcode 10.
 
+## LLDB Integration
+Please copy and add follows to your `~/.ldbinit` (please create the file if the file doesn't exist):
+```text
+command regex _p  's/(.+)/e -l swift -o -- Pretty.print(%1)/'
+command regex _pp 's/(.+)/e -l swift -o -- Pretty.prettyPrint(%1)/'
+```
+
+This let you to use the lldb command in debug console as follows:
+```text
+(lldb) _p dog
+Dog(id: "pochi", price: 10.0, name: "ポチ")
+
+(lldb) _pp dog
+Dog(
+    id: "pochi",
+    price: 10.0,
+    name: "ポチ"
+)
+```
+
 ## Recommend Settings 📝
 
 If you don't want to write an `import` statement when debugging.
@@ -392,26 +412,6 @@ Debug.prettyPrint(label: "array", array)
 
 Note:
 This can't be used to the operator-based API such as `p >>>`. (This is a Swift language's limitation)
-
-### Debug Settings
-Please copy and add follows to your `~/.ldbinit` (please create the file if the file doesn't exist):
-```text
-command regex _p  's/(.+)/e -l swift -o -- Pretty.print(%1)/'
-command regex _pp 's/(.+)/e -l swift -o -- Pretty.prettyPrint(%1)/'
-```
-
-This let you to use the lldb command in debug console as follows:
-```text
-(lldb) _p dog
-Dog(id: "pochi", price: 10.0, name: "ポチ")
-
-(lldb) _pp dog
-Dog(
-    id: "pochi",
-    price: 10.0,
-    name: "ポチ"
-)
-```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -393,6 +393,22 @@ Debug.prettyPrint(label: "array", array)
 Note:
 This can't be used to the operator-based API such as `p >>>`. (This is a Swift language's limitation)
 
+### Debug Settings
+It is recommended to move `.lldbinit` to` ~ / .lldbinit` to easier to debugging with SwiftPrettyPrint.
+This let you to use the lldb command in debug console as follows:
+
+```
+(lldb) _p dog
+Dog(id: "pochi", price: 10.0, name: "ポチ")
+
+(lldb) _pp dog
+Dog(
+    id: "pochi",
+    price: 10.0,
+    name: "ポチ"
+)
+```
+
 ## Development
 
 Require:

--- a/README.md
+++ b/README.md
@@ -394,10 +394,14 @@ Note:
 This can't be used to the operator-based API such as `p >>>`. (This is a Swift language's limitation)
 
 ### Debug Settings
-It is recommended to move `.lldbinit` to `~/.lldbinit` to easier to debugging with SwiftPrettyPrint.
-This let you to use the lldb command in debug console as follows:
-
+Please copy and add follows to your `~/.ldbinit` (please create the file if the file doesn't exist):
+```text
+command regex _p  's/(.+)/e -l swift -o -- Pretty.print(%1)/'
+command regex _pp 's/(.+)/e -l swift -o -- Pretty.prettyPrint(%1)/'
 ```
+
+This let you to use the lldb command in debug console as follows:
+```text
 (lldb) _p dog
 Dog(id: "pochi", price: 10.0, name: "ポチ")
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Note:
 This can't be used to the operator-based API such as `p >>>`. (This is a Swift language's limitation)
 
 ### Debug Settings
-It is recommended to move `.lldbinit` to` ~ / .lldbinit` to easier to debugging with SwiftPrettyPrint.
+It is recommended to move `.lldbinit` to `~/.lldbinit` to easier to debugging with SwiftPrettyPrint.
 This let you to use the lldb command in debug console as follows:
 
 ```


### PR DESCRIPTION
# As is
As using SwiftPrettyPrint in debug console. developers input long commands like the following.
```
(lldb) e pp >>> dog
```

# To be
By defining command for LLDB, developers can use SwiftPrettyPrint with less inputs.
```
(lldb) _p dog
(lldb) _pp dog
```
<img width="200" alt="Screen Shot 2020-12-15 at 9 08 59" src="https://user-images.githubusercontent.com/14083051/102151029-3985ba00-3eb5-11eb-8fe5-d7d648c4d271.png">


