### PR TITLE
Support: lowmad

### DIFF
--- a/.lldbinit
+++ b/.lldbinit
@@ -1,3 +1,0 @@
-command regex _p  's/(.+)/e -l swift -o -- Pretty.print(%1)/'
-command regex _pp 's/(.+)/e -l swift -o -- Pretty.prettyPrint(%1)/'
-

--- a/LLDB/swift_pretty_print.py
+++ b/LLDB/swift_pretty_print.py
@@ -1,0 +1,28 @@
+import lldb
+import os
+import shlex
+import optparse
+
+def __lldb_init_module(debugger, internal_dict):
+    debugger.HandleCommand("command regex _p  's/(.+)/e -l swift -o -- Pretty.print(%1)/'")
+    debugger.HandleCommand("command regex _pp 's/(.+)/e -l swift -o -- Pretty.prettyPrint(%1)/'")
+    # debugger.HandleCommand('command script add -f swift_pretty_print.handle_command swift_pretty_print -h "Short documentation here"')
+
+def handle_command(debugger, command, exe_ctx, result, internal_dict):
+    command_args = shlex.split(command, posix=False)
+    parser = generate_option_parser()
+    try:
+        (options, args) = parser.parse_args(command_args)
+    except:
+        result.SetError(parser.usage)
+        return
+
+    # Uncomment if you are expecting at least one argument
+    # clean_command = shlex.split(args[0])[0]
+
+    result.AppendMessage('Hello! the swift_pretty_print command is working!')
+
+def generate_option_parser():
+    usage = "usage: %prog [options] TODO Description Here :]"
+    parser = optparse.OptionParser(usage=usage, prog="swift_pretty_print")
+    return parser

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ SwiftPrettyPrint gives **Human-readable outputs** than `print()`, `debugPrint()`
    - [CocoaPods (Recommended)](#CocoaPods-(Recommended))
    - [Carthage](#Carthage)
    - [Swift Package Manager](#Swift-Package-Manager)
+ - [LLDB Integration](LLDB-Integration) 
  - [Recommend Settings](#Recommend-Settings-📝)
  - [Development](#Development)
  - [Author](#Author)
@@ -407,13 +408,22 @@ let package = Package(
 Alternatively, use Xcode integration. This function is available since Xcode 10.
 
 ## LLDB Integration
+
 Please copy and add follows to your `~/.ldbinit` (please create the file if the file doesn't exist):
+
 ```text
 command regex _p  's/(.+)/e -l swift -o -- Pretty.print(%1)/'
 command regex _pp 's/(.+)/e -l swift -o -- Pretty.prettyPrint(%1)/'
 ```
 
+or install via [lowmad](https://github.com/bangerang/lowmad):
+
+```text
+$ lowmad install https://github.com/YusukeHosonuma/SwiftPrettyPrint.git
+```
+
 This let you to use the lldb command in debug console as follows:
+
 ```text
 (lldb) _p dog
 Dog(id: "pochi", price: 10.0, name: "ポチ")


### PR DESCRIPTION
ref #129 

This will allow you to install with a single command. (If [lowmad](https://github.com/bangerang/lowmad) is installed)

**Follows bug was fixed.**

~Note:
The lowmad is include bug that `--commit` option of `install` command is not work.
https://github.com/bangerang/lowmad/pull/1~

~Please build like as follows if you try install from this PR:~

```bash
$ git clone https://github.com/YusukeHosonuma/lowmad/
$ git checkout fix/checkout
$ swift build
$ .build/debug/lowmad install -c support/lowmad https://github.com/YusukeHosonuma/SwiftPrettyPrint.git
```
