### PR TITLE
Update Data.withUnsafeBytes method to new version

### DIFF
--- a/Sources/Core/Log/LogOutputStream.swift
+++ b/Sources/Core/Log/LogOutputStream.swift
@@ -31,8 +31,11 @@
             defer { output.close() }
 
             guard let data = string.data(using: .utf8) else { return }
-            let result = data.withUnsafeBytes {
-                output.write($0, maxLength: data.count)
+            data.withUnsafeBytes { ptr in
+                guard let bytes = ptr.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
+                    return
+                }
+                output.write(bytes, maxLength: data.count)
             }
         }
     }


### PR DESCRIPTION
The following complie warnings have been resolved in this PR:

> 'withUnsafeBytes' is deprecated: use `withUnsafeBytes<R>(_: (UnsafeRawBufferPointer) throws -> R) rethrows -> R` instead

> Initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it

# how to

Use 

[`Data.withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R`](https://developer.apple.com/documentation/swift/array/2635991-withunsafebytes) 

and 

[`UnsafeRawPointer.assumingMemoryBound<T>(to: T.Type) -> UnsafePointer<T>`](https://developer.apple.com/documentation/swift/unsaferawpointer/2431721-assumingmemorybound) 

instead of 

[`Data.withUnsafeBytes<ResultType, ContentType>(_ body: (UnsafePointer<ContentType>) throws -> ResultType) rethrows -> ResultType`](https://developer.apple.com/documentation/foundation/data/1780450-withunsafebytes).

# Reference

[withUnsafeBytes(_:) | Apple Developer Documentation](https://developer.apple.com/documentation/foundation/data/1780450-withunsafebytes) (deprecated)

[withUnsafeBytes(_:) | Apple Developer Documentation](https://developer.apple.com/documentation/swift/array/2635991-withunsafebytes)

[UnsafeRawPointer | Apple Developer Documentation](https://developer.apple.com/documentation/swift/unsaferawpointer)

[assumingMemoryBound(to:) | Apple Developer Documentation](https://developer.apple.com/documentation/swift/unsaferawpointer/2431721-assumingmemorybound)

[withUnsafeBytes deprecated, is thi… | Apple Developer Forums](https://developer.apple.com/forums/thread/116309)

[Swift.org - UnsafeRawPointer Migration](https://swift.org/migration-guide-swift3/se-0107-migrate.html)

[swift-evolution/0107-unsaferawpointer.md at master · apple/swift-evolution](https://github.com/apple/swift-evolution/blob/master/proposals/0107-unsaferawpointer.md#binding-memory-type)

[素晴らしいSwiftのポインタ型の解説 - Qiita](https://qiita.com/omochimetaru/items/c95e0d36ae7f1b1a9052) (In Japanese only)