### PR TITLE
Separete argument names into internal and external argument names

### DIFF
--- a/Sources/Public/CombineExtension.swift
+++ b/Sources/Public/CombineExtension.swift
@@ -48,17 +48,17 @@
             _ prefix: String = "",
             when: [CombineOperatorOption.Event] = CombineOperatorOption.Event.allCases,
             format: CombineOperatorOption.Format = .multiline,
-            to: Output
+            to output: Output
         ) -> Publishers.HandleEvents<Self> {
             // Note:
             // Use local function for capture arguments.
 
-            func _out<Output: TextOutputStream>(_ value: String, terminator: String = "\n", to: Output) {
+            func _out<Output: TextOutputStream>(_ value: String, terminator: String = "\n", to output: Output) {
                 let message = prefix.isEmpty
                     ? "\(value)"
                     : "\(prefix): \(value)"
 
-                var out = to
+                var out = output
                 Swift.print(message, terminator: terminator, to: &out)
             }
 
@@ -66,12 +66,12 @@
                 guard when.contains(type) else { return }
 
                 // Console
-                _out(value, to: to)
+                _out(value, to: output)
 
                 // Log files
                 #if targetEnvironment(simulator) || os(macOS)
                     // Do not output to log when specifed `Output`.
-                    if to is StandardOutput {
+                    if output is StandardOutput {
                         _out(value, to: Pretty.plainLogStream)
                         _out(value, to: Pretty.coloredLogStream)
                     }
@@ -95,13 +95,13 @@
                         Pretty.prettyPrint(value, option: option, to: &plain)
                     }
 
-                    _out(plain, terminator: "", to: to)
+                    _out(plain, terminator: "", to: output)
                 }
 
                 // Log files
                 #if targetEnvironment(simulator) || os(macOS)
                     // Do not output to log when specifed `Output`.
-                    if to is StandardOutput {
+                    if output is StandardOutput {
                         var colored: String = ""
 
                         switch format {


### PR DESCRIPTION
In CombineExtension.swift, arguments named `to` cause misleading codes like `var out = to`,  `_out(value, to: to)` and `if to is StandardOutput`.

Such confusion can be resolved by separating the external and internal argument names.

Specifically, `to` should be changed to `to output`. This change impromves the previous awkwrd codes as follows:

`var out = output`

`_out(value, to: output)`

`if output is StandardOutput`

# Discussion

As a matter of fact, this separation of argument names is already done in the `prettyPrint` method in Pretty.swift, so the changes made in this PR can improve consistency between that existing interface in Pretty.swift and the one in CombineExtension.swift.