### PR TITLE
Add section headings to logs

### DIFF
--- a/Example/SwiftPrettyPrintExample.xcodeproj/project.pbxproj
+++ b/Example/SwiftPrettyPrintExample.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		20F00923ACB364A57C37E2C4 /* Pods_SwiftPrettyPrintExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFCD0B73BE04DAE6F974CF97 /* Pods_SwiftPrettyPrintExample.framework */; };
+		63F836B925C249F800FA4006 /* Section.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F836B825C249F800FA4006 /* Section.swift */; };
 		7032C8502576113900428353 /* ContentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7032C84F2576113900428353 /* ContentViewModel.swift */; };
 		E560881423FB6EA2006AB5D0 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = E560881323FB6EA2006AB5D0 /* Debug.swift */; };
 		E560881C23FB707F006AB5D0 /* Dog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E560881B23FB707F006AB5D0 /* Dog.swift */; };
@@ -35,6 +36,7 @@
 		13713262837E11A7F3C73644 /* Pods-SwiftPrettyPrintExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPrettyPrintExample.release.xcconfig"; path = "Target Support Files/Pods-SwiftPrettyPrintExample/Pods-SwiftPrettyPrintExample.release.xcconfig"; sourceTree = "<group>"; };
 		3B3B027DA6D075BA3D67CED7 /* Pods_SwiftPrettyPrintExampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SwiftPrettyPrintExampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		487D9DEBB0BCBEBDF923F3A4 /* Pods-SwiftPrettyPrintExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPrettyPrintExampleTests.release.xcconfig"; path = "Target Support Files/Pods-SwiftPrettyPrintExampleTests/Pods-SwiftPrettyPrintExampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		63F836B825C249F800FA4006 /* Section.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Section.swift; sourceTree = "<group>"; };
 		7032C84F2576113900428353 /* ContentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewModel.swift; sourceTree = "<group>"; };
 		825B48CD5C133ED74B872617 /* Pods-SwiftPrettyPrintExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPrettyPrintExample.debug.xcconfig"; path = "Target Support Files/Pods-SwiftPrettyPrintExample/Pods-SwiftPrettyPrintExample.debug.xcconfig"; sourceTree = "<group>"; };
 		A8B066E3D7B5E0CBBFE5D278 /* Pods-SwiftPrettyPrintExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftPrettyPrintExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-SwiftPrettyPrintExampleTests/Pods-SwiftPrettyPrintExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				E5E842E523FB6B3900391E9F /* SceneDelegate.swift */,
 				E5E842E723FB6B3900391E9F /* ContentView.swift */,
 				7032C84F2576113900428353 /* ContentViewModel.swift */,
+				63F836B825C249F800FA4006 /* Section.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -335,6 +338,7 @@
 				E5E842E423FB6B3900391E9F /* AppDelegate.swift in Sources */,
 				E560881423FB6EA2006AB5D0 /* Debug.swift in Sources */,
 				7032C8502576113900428353 /* ContentViewModel.swift in Sources */,
+				63F836B925C249F800FA4006 /* Section.swift in Sources */,
 				E5E842E623FB6B3900391E9F /* SceneDelegate.swift in Sources */,
 				E560881C23FB707F006AB5D0 /* Dog.swift in Sources */,
 				E5E842E823FB6B3900391E9F /* ContentView.swift in Sources */,

--- a/Example/SwiftPrettyPrintExample/Source/AppDelegate.swift
+++ b/Example/SwiftPrettyPrintExample/Source/AppDelegate.swift
@@ -19,6 +19,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // --------
         // Example
         // --------
+
+        *"Example"*
+
         let dog = Dog(id: DogId(rawValue: "pochi"), price: Price(rawValue: 10.0), name: "ポチ")
 
         Debug.print(dog)

--- a/Example/SwiftPrettyPrintExample/Source/AppDelegate.swift
+++ b/Example/SwiftPrettyPrintExample/Source/AppDelegate.swift
@@ -20,7 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Example
         // --------
 
-        *"Example"*
+        printSection("Example")
 
         let dog = Dog(id: DogId(rawValue: "pochi"), price: Price(rawValue: 10.0), name: "ポチ")
 

--- a/Example/SwiftPrettyPrintExample/Source/AppDelegate.swift
+++ b/Example/SwiftPrettyPrintExample/Source/AppDelegate.swift
@@ -74,6 +74,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // -------------------
         // Swift standard API
         // -------------------
+        print(
+            """
+            --------------------
+             Swift standard API
+            --------------------
+            """
+        )
         print(dog)
         // => Dog(id: SwiftPrettyPrintExample.DogId(rawValue: "pochi"), price: SwiftPrettyPrintExample.Price(rawValue: 10.0), name: Optional("ポチ"))
 

--- a/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
+++ b/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
@@ -16,6 +16,8 @@ final class ContentViewModel: ObservableObject {
         let dog1 = Dog(id: DogId(rawValue: "pochi"), price: Price(rawValue: 10.0), name: "ポチ")
         let dog2 = Dog(id: DogId(rawValue: "koro"), price: Price(rawValue: 20.0), name: "コロ")
 
+        *"Combine Example"*
+
         [dog1]
             .publisher
             .prettyPrint("🐕", when: [.output, .completion], format: .multiline)

--- a/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
+++ b/Example/SwiftPrettyPrintExample/Source/ContentViewModel.swift
@@ -16,7 +16,7 @@ final class ContentViewModel: ObservableObject {
         let dog1 = Dog(id: DogId(rawValue: "pochi"), price: Price(rawValue: 10.0), name: "ポチ")
         let dog2 = Dog(id: DogId(rawValue: "koro"), price: Price(rawValue: 20.0), name: "コロ")
 
-        *"Combine Example"*
+        printSection("Combine Example")
 
         [dog1]
             .publisher

--- a/Example/SwiftPrettyPrintExample/Source/Section.swift
+++ b/Example/SwiftPrettyPrintExample/Source/Section.swift
@@ -1,0 +1,55 @@
+//
+//  Section.swift
+//  SwiftPrettyPrintExample
+//
+//  Created by ogasawara on 2021/01/28.
+//  Copyright © 2021 Yusuke Hosonuma. All rights reserved.
+//
+import ColorizeSwift
+import SwiftPrettyPrint
+
+prefix operator *
+postfix operator *
+
+extension String {
+    /// Output a section heading to console and log files.
+    /// - Parameter heading: a section heading
+    /// # Reference
+    /// [section method](x-source-tag://section)
+    static prefix func * (heading: String) {
+        section(heading)
+    }
+
+    /// Return the previous string as is.
+    /// - Parameter heading: a section heading
+    /// - Returns: String received as argument
+    /// - Note: This postfix operator expresses in the source code that the preceding string is a heading. The prefix operator `*` alone is difficult to distinguish from the operator for multiplication when reading source codes.
+    static postfix func * (heading: String) -> String {
+        heading
+    }
+}
+
+/// Output a section heading to console and log files.
+/// - Parameter heading: a section heading
+/// - Note: heading strings are displayed in bold on colored log files.
+/// - Tag: section
+func section(_ heading: String) {
+    let separator = String(repeating: "-", count: heading.count + 2)
+    let theme: ColorTheme = {
+        var theme = ColorTheme.plain
+        theme.stringLiteral = { $0.bold() }
+        return theme
+    }()
+    let sectionOption = Debug.Option(theme: theme)
+
+    Debug.print(
+        """
+
+        \(separator)
+         \(heading)
+        \(separator)
+
+        """,
+        option: sectionOption
+    )
+}

--- a/Example/SwiftPrettyPrintExample/Source/Section.swift
+++ b/Example/SwiftPrettyPrintExample/Source/Section.swift
@@ -8,32 +8,11 @@
 import ColorizeSwift
 import SwiftPrettyPrint
 
-prefix operator *
-postfix operator *
-
-extension String {
-    /// Output a section heading to console and log files.
-    /// - Parameter heading: a section heading
-    /// # Reference
-    /// [section method](x-source-tag://section)
-    static prefix func * (heading: String) {
-        section(heading)
-    }
-
-    /// Return the previous string as is.
-    /// - Parameter heading: a section heading
-    /// - Returns: String received as argument
-    /// - Note: This postfix operator expresses in the source code that the preceding string is a heading. The prefix operator `*` alone is difficult to distinguish from the operator for multiplication when reading source codes.
-    static postfix func * (heading: String) -> String {
-        heading
-    }
-}
-
 /// Output a section heading to console and log files.
 /// - Parameter heading: a section heading
 /// - Note: heading strings are displayed in bold on colored log files.
 /// - Tag: section
-func section(_ heading: String) {
+func printSection(_ heading: String) {
     let separator = String(repeating: "-", count: heading.count + 2)
     let theme: ColorTheme = {
         var theme = ColorTheme.plain


### PR DESCRIPTION
In the example project, section headings are added to the usage examples that are output to the console and two different log files.

Specifically, section headings have been added to the "Example" and "Swift standard API" in `application(_ , didFinishLaunchingWithOptions)` in AppDelegate and `init` in ContentViewModel.

## Usage

### Console on Xcode

<img width="353" alt=" 2021-01-28 20 05 57" src="https://user-images.githubusercontent.com/26447279/106135671-97dbd300-61ab-11eb-87c5-5c50d5f1cf90.png">
<img width="215" alt=" 2021-01-28 20 06 11" src="https://user-images.githubusercontent.com/26447279/106135678-99a59680-61ab-11eb-9be0-cab8e0010dde.png">
<img width="183" alt=" 2021-01-28 20 06 21" src="https://user-images.githubusercontent.com/26447279/106135682-9ad6c380-61ab-11eb-9852-3322f5a915fe.png">

### output.log

<img width="334" alt=" 2021-01-28 20 10 09" src="https://user-images.githubusercontent.com/26447279/106136086-1e90b000-61ac-11eb-97aa-d6ddbe3e74cb.png">
<img width="145" alt=" 2021-01-28 20 10 20" src="https://user-images.githubusercontent.com/26447279/106136091-1fc1dd00-61ac-11eb-93df-8aec006d406b.png">

### output-colored.log

<img width="341" alt=" 2021-01-28 20 09 20" src="https://user-images.githubusercontent.com/26447279/106136133-30725300-61ac-11eb-9a13-10bf81f1fd80.png">
<img width="147" alt=" 2021-01-28 20 08 34" src="https://user-images.githubusercontent.com/26447279/106136148-37996100-61ac-11eb-9613-064d9a0ea50e.png">


## As is

In the source code of example project, In AppDelegate, although comments are written for each output method, the comments are not reflected in the resulting console and log files. That makes it difficult to read that the output method was switched in the middle of the log.
In particular, it is difficult to tell that the log is being output by both AppDelegate.swift and ContentView.swift, which is a problem with the example.

## To be

In order to read the output method and context from the log without referring to the source code, I add a heading for each category.

For the Swift standard API output example, the existing example itself only outputs to the console, and the section headings follow that policy.

For the other examples, section headings have been added to the output of the console and the two types of log files.