### PR TITLE
Update the version of SwiftParamTest to 2.2.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -20,12 +20,30 @@
         }
       },
       {
+        "package": "Flatten",
+        "repositoryURL": "https://github.com/YusukeHosonuma/Flatten.git",
+        "state": {
+          "branch": null,
+          "revision": "5286148aa255f57863e0d7e2b827ca6b91677051",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "package": "SHList",
+        "repositoryURL": "https://github.com/YusukeHosonuma/SHList.git",
+        "state": {
+          "branch": null,
+          "revision": "6c61f5382dd07a64d76bc8b7fad8cec0d8a4ff7a",
+          "version": "0.1.0"
+        }
+      },
+      {
         "package": "SwiftParamTest",
         "repositoryURL": "https://github.com/YusukeHosonuma/SwiftParamTest.git",
         "state": {
           "branch": null,
-          "revision": "218fbf3541671a9341491dd67c9b4ab3f23e16a2",
-          "version": "2.2.0"
+          "revision": "f513e1dbbdd86e2ca2b672537f4bcb4417f94c27",
+          "version": "2.2.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "SwiftPrettyPrint", targets: ["SwiftPrettyPrint"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/YusukeHosonuma/SwiftParamTest.git", from: "2.2.0"),
+        .package(url: "https://github.com/YusukeHosonuma/SwiftParamTest.git", from: "2.2.1"),
         .package(url: "https://github.com/thoughtbot/Curry.git", from: "4.0.2"),
         .package(url: "https://github.com/mtynior/ColorizeSwift.git", from: "1.5.0"),
     ],


### PR DESCRIPTION
Reduce the warnings related to the usage of `_functionBuilder` in SwiftParamTest.