### PR TITLE
Use relative-path to reference image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![License](https://img.shields.io/github/license/YusukeHosonuma/SwiftPrettyPrint)](https://github.com/YusukeHosonuma/SwiftPrettyPrint/blob/main/LICENSE)
 [![Twitter](https://img.shields.io/twitter/url?style=social&url=https%3A%2F%2Ftwitter.com%2Ftobi462)](https://twitter.com/tobi462)
 
-![Logo](https://raw.githubusercontent.com/YusukeHosonuma/SwiftPrettyPrint/main/Image/logo.png)
+![Logo](Image/logo.png)
 
 SwiftPrettyPrint gives **Human-readable outputs** than `print()`, `debugPrint()` and `dump()` in Swift standard library.
 
-![Screenshot](https://raw.githubusercontent.com/YusukeHosonuma/SwiftPrettyPrint/main/Image/screenshot.png)
+![Screenshot](Image/screenshot.png)
 
 ## Features 🚀
 


### PR DESCRIPTION
In the review comments for PR #173, it was suggested that in README.md URLs referring to images in the `Image` folder should be written as relative paths ( [link](https://github.com/YusukeHosonuma/SwiftPrettyPrint/pull/173#discussion_r839158726)). 

On the other hand, some existing descriptions in README.md specify image URLs as absolute paths.

This PR eliminates the above-mentioned confusion by replacing absolute image paths with relative paths.