### PR TITLE
support: SwiftUI property wrappers

### DIFF
--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -179,6 +179,10 @@ struct PrettyDescriber {
         // SwiftUI Library
         //
         #if canImport(SwiftUI)
+            func __string<T: Any>(_ target: T) -> String {
+                string(target, debug: debug) // ☑️ Capture `debug`
+            }
+
             let typeName = String(describing: target.self)
 
             let propertyWrappers: [(String, String)] = [
@@ -191,14 +195,12 @@ struct PrettyDescriber {
             ]
 
             for (type, key) in propertyWrappers {
-                if typeName.hasPrefix("\(type)<") {
-                    if let value = lookup(key, from: target) {
-                        if debug {
-                            // e.g. `@Published(42)`
-                            return "@\(type)(\(string(value, debug: debug)))"
-                        } else {
-                            return string(value, debug: debug)
-                        }
+                if typeName.hasPrefix("\(type)<"), let value = lookup(key, from: target) {
+                    if debug {
+                        // e.g. `@Published(42)`
+                        return "@\(type)(\(__string(value)))"
+                    } else {
+                        return __string(value)
                     }
                 }
             }
@@ -206,30 +208,27 @@ struct PrettyDescriber {
             //
             // @Environment
             //
-            if typeName.hasPrefix("Environment<") {
-                if let content = lookup("content", from: target),
-                    let rawValue = Mirror(reflecting: content).children.first?.value {
-                    if debug {
-                        return "@Environment(\(string(rawValue, debug: debug)))"
-                    } else {
-                        return string(rawValue, debug: debug)
-                    }
+            if typeName.hasPrefix("Environment<"),
+                let content = lookup("content", from: target),
+                let rawValue = Mirror(reflecting: content).children.first?.value {
+                if debug {
+                    return "@Environment(\(__string(rawValue)))"
+                } else {
+                    return __string(rawValue)
                 }
             }
 
             //
             // @AppStorage
             //
-            if typeName.hasPrefix("AppStorage<") {
-                if let key = lookup("key", from: target) as? String {
-                    let value = UserDefaults.standard.value(forKey: key) ?? "nil"
+            if typeName.hasPrefix("AppStorage<"), let key = lookup("key", from: target) as? String {
+                let value = UserDefaults.standard.value(forKey: key) ?? "nil"
 
-                    if debug {
-                        // e.g. `@AppStorage(key: "Number", userDefaultsValue: 42)`
-                        return "@AppStorage(key: \"\(key)\", userDefaultsValue: \(string(value, debug: debug)))"
-                    } else {
-                        return string(value, debug: debug)
-                    }
+                if debug {
+                    // e.g. `@AppStorage(key: "Number", userDefaultsValue: 42)`
+                    return "@AppStorage(key: \"\(key)\", userDefaultsValue: \(__string(value)))"
+                } else {
+                    return __string(value)
                 }
             }
 
@@ -241,19 +240,19 @@ struct PrettyDescriber {
 
                 switch target {
                 case let storage as SceneStorage<URL>:
-                    value = string(storage.wrappedValue, debug: debug)
+                    value = __string(storage.wrappedValue)
 
                 case let storage as SceneStorage<Int>:
-                    value = string(storage.wrappedValue, debug: debug)
+                    value = __string(storage.wrappedValue)
 
                 case let storage as SceneStorage<Double>:
-                    value = string(storage.wrappedValue, debug: debug)
+                    value = __string(storage.wrappedValue)
 
                 case let storage as SceneStorage<String>:
-                    value = string(storage.wrappedValue, debug: debug)
+                    value = __string(storage.wrappedValue)
 
                 case let storage as SceneStorage<Bool>:
-                    value = string(storage.wrappedValue, debug: debug)
+                    value = __string(storage.wrappedValue)
 
                 default:
                     //

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -189,6 +189,46 @@ struct PrettyDescriber {
                     }
                 }
             }
+
+            //
+            // @SceneStorage
+            //
+            if #available(iOS 14, *), typeName.hasPrefix("SceneStorage<"), let key = lookup("_key", from: target) as? String {
+                let value: String
+
+                switch target {
+                case let storage as SceneStorage<URL>:
+                    value = string(storage.wrappedValue, debug: debug)
+
+                case let storage as SceneStorage<Int>:
+                    value = string(storage.wrappedValue, debug: debug)
+
+                case let storage as SceneStorage<Double>:
+                    value = string(storage.wrappedValue, debug: debug)
+
+                case let storage as SceneStorage<String>:
+                    value = string(storage.wrappedValue, debug: debug)
+
+                case let storage as SceneStorage<Bool>:
+                    value = string(storage.wrappedValue, debug: debug)
+
+                default:
+                    //
+                    // Can't lookup value that implemented `RawRepresentable` protocol.
+                    //
+                    if debug {
+                        return "@SceneStorage(key: \"\(key)\", value: <can not lookup>)"
+                    } else {
+                        return "<can not lookup>"
+                    }
+                }
+
+                if debug {
+                    return "@SceneStorage(key: \"\(key)\", value: \(value))"
+                } else {
+                    return value
+                }
+            }
         #endif
 
         //

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -158,6 +158,7 @@ struct PrettyDescriber {
                 ("ObservedObject", "wrappedValue"),
                 ("EnvironmentObject", "_store"),
                 ("State", "_value"),
+                ("Binding", "_value"),
             ]
 
             for (type, key) in propertyWrappers {

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -177,6 +177,19 @@ struct PrettyDescriber {
                     }
                 }
             }
+
+            //
+            // @ObservedObject
+            //
+            if typeName.hasPrefix("ObservedObject<") {
+                if let currentValue = lookup("wrappedValue", from: target) {
+                    if debug {
+                        return "@ObservedObject(\(string(currentValue, debug: debug)))"
+                    } else {
+                        return string(currentValue, debug: debug)
+                    }
+                }
+            }
         #endif
 
         //

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -157,6 +157,7 @@ struct PrettyDescriber {
                 ("StateObject", "wrappedValue"),
                 ("ObservedObject", "wrappedValue"),
                 ("EnvironmentObject", "_store"),
+                ("State", "_value"),
             ]
 
             for (type, key) in propertyWrappers {

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -102,7 +102,13 @@ struct PrettyDescriber {
 
         // Object
         let fields: [(String, String)] = mirror.children.map {
-            ($0.label ?? "-", _string($0.value))
+            let value = _string($0.value)
+
+            if isSwiftUIPropertyWrapperType($0.value), let label = $0.label, label.first == "_" {
+                return (String(label.dropFirst()), value) // e.g. `_text` -> `text`
+            } else {
+                return ($0.label ?? "-", value)
+            }
         }
         return formatter.objectString(typeName: typeName, fields: fields)
     }

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -165,10 +165,27 @@ struct PrettyDescriber {
                 if typeName.hasPrefix("\(type)<") {
                     if let currentValue = lookup(key, from: target) {
                         if debug {
+                            // e.g. `@Published(42)`
                             return "@\(type)(\(string(currentValue, debug: debug)))"
                         } else {
                             return string(currentValue, debug: debug)
                         }
+                    }
+                }
+            }
+
+            //
+            // @AppStorage
+            //
+            if typeName.hasPrefix("AppStorage<") {
+                if let key = lookup("key", from: target) as? String {
+                    let value = UserDefaults.standard.value(forKey: key) ?? "nil"
+
+                    if debug {
+                        // e.g. `@AppStorage(key: "Number", userDefaultsValue: 42)`
+                        return "@AppStorage(key: \"\(key)\", userDefaultsValue: \(string(value, debug: debug)))"
+                    } else {
+                        return string(value, debug: debug)
                     }
                 }
             }

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -190,6 +190,19 @@ struct PrettyDescriber {
                     }
                 }
             }
+
+            //
+            // @EnvironmentObject
+            //
+            if typeName.hasPrefix("EnvironmentObject<") {
+                if let currentValue = lookup("_store", from: target) {
+                    if debug {
+                        return "@EnvironmentObject(\(string(currentValue, debug: debug)))"
+                    } else {
+                        return string(currentValue, debug: debug)
+                    }
+                }
+            }
         #endif
 
         //

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -235,7 +235,9 @@ struct PrettyDescriber {
             //
             // @SceneStorage
             //
-            if #available(iOS 14, *), typeName.hasPrefix("SceneStorage<"), let key = lookup("_key", from: target) as? String {
+            if #available(iOS 14, macOS 11.0,*),
+                typeName.hasPrefix("SceneStorage<"),
+                let key = lookup("_key", from: target) as? String {
                 let value: String
 
                 switch target {

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -152,54 +152,21 @@ struct PrettyDescriber {
         #if canImport(SwiftUI)
             let typeName = String(describing: target.self)
 
-            //
-            // @Published
-            //
-            if typeName.hasPrefix("Published<") {
-                if let currentValue = lookup("currentValue", from: target) {
-                    if debug {
-                        return "@Published(\(string(currentValue, debug: debug)))"
-                    } else {
-                        return string(currentValue, debug: debug)
-                    }
-                }
-            }
+            let propertyWrappers: [(String, String)] = [
+                ("Published", "currentValue"),
+                ("StateObject", "wrappedValue"),
+                ("ObservedObject", "wrappedValue"),
+                ("EnvironmentObject", "_store"),
+            ]
 
-            //
-            // @StateObject
-            //
-            if typeName.hasPrefix("StateObject<") {
-                if let currentValue = lookup("wrappedValue", from: target) {
-                    if debug {
-                        return "@StateObject(\(string(currentValue, debug: debug)))"
-                    } else {
-                        return string(currentValue, debug: debug)
-                    }
-                }
-            }
-
-            //
-            // @ObservedObject
-            //
-            if typeName.hasPrefix("ObservedObject<") {
-                if let currentValue = lookup("wrappedValue", from: target) {
-                    if debug {
-                        return "@ObservedObject(\(string(currentValue, debug: debug)))"
-                    } else {
-                        return string(currentValue, debug: debug)
-                    }
-                }
-            }
-
-            //
-            // @EnvironmentObject
-            //
-            if typeName.hasPrefix("EnvironmentObject<") {
-                if let currentValue = lookup("_store", from: target) {
-                    if debug {
-                        return "@EnvironmentObject(\(string(currentValue, debug: debug)))"
-                    } else {
-                        return string(currentValue, debug: debug)
+            for (type, key) in propertyWrappers {
+                if typeName.hasPrefix("\(type)<") {
+                    if let currentValue = lookup(key, from: target) {
+                        if debug {
+                            return "@\(type)(\(string(currentValue, debug: debug)))"
+                        } else {
+                            return string(currentValue, debug: debug)
+                        }
                     }
                 }
             }

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -163,13 +163,27 @@ struct PrettyDescriber {
 
             for (type, key) in propertyWrappers {
                 if typeName.hasPrefix("\(type)<") {
-                    if let currentValue = lookup(key, from: target) {
+                    if let value = lookup(key, from: target) {
                         if debug {
                             // e.g. `@Published(42)`
-                            return "@\(type)(\(string(currentValue, debug: debug)))"
+                            return "@\(type)(\(string(value, debug: debug)))"
                         } else {
-                            return string(currentValue, debug: debug)
+                            return string(value, debug: debug)
                         }
+                    }
+                }
+            }
+
+            //
+            // @Environment
+            //
+            if typeName.hasPrefix("Environment<") {
+                if let content = lookup("content", from: target),
+                    let rawValue = Mirror(reflecting: content).children.first?.value {
+                    if debug {
+                        return "@Environment(\(string(rawValue, debug: debug)))"
+                    } else {
+                        return string(rawValue, debug: debug)
                     }
                 }
             }

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -396,14 +396,14 @@ struct PrettyDescriber {
     }
 
     private func lookup(_ key: String, from target: Any) -> Any? {
-        for children in Mirror(reflecting: target).children {
+        for child in Mirror(reflecting: target).children {
             // 💡 Prevent infinite recursive call.
-            guard let label = children.label else { continue }
+            guard let label = child.label else { continue }
 
             if label == key {
-                return children.value
+                return child.value
             } else {
-                if let found = lookup(key, from: children.value) { // ☑️ Recursive call.
+                if let found = lookup(key, from: child.value) { // ☑️ Recursive call.
                     return found
                 }
             }


### PR DESCRIPTION
Support property wrappers of SwiftUI.

- [x] Support basic types
  - [x] `@Published` (supported in #179 )
  - [x] `@StateObject`
  - [x] `@ObservedObject` 
  - [x] `@EnvironmentObject`
  - [x] `@Environment`
  - [x] `@State`
  - [x] `@Binding`
  - [x] `@AppStorage`
  - [x] `@SceneStorage`
- [x] Improve: remove first `_` from property label

| `prettyPrint()` | `prettyPrintDebug()` |
| -- | -- |
| <img width="311" alt="image" src="https://user-images.githubusercontent.com/2990285/166919365-2080ef07-792b-42e3-840f-8b4f3d88db69.png"> | <img width="611" alt="image" src="https://user-images.githubusercontent.com/2990285/166919401-f9af7e2a-16dd-4121-8e22-2b0fa1b367cf.png"> |