### PR TITLE
support: `@GestureState`

### DIFF
--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -150,6 +150,7 @@ struct PrettyDescriber {
             "Binding",
             "AppStorage",
             "SceneStorage",
+            "GestureState",
         ].contains { typeName.hasPrefix("\($0)<") }
     }
 
@@ -192,6 +193,7 @@ struct PrettyDescriber {
                 ("EnvironmentObject", "_store"),
                 ("State", "_value"),
                 ("Binding", "_value"),
+                ("GestureState", "_value"), // Lookup @State's value.
             ]
 
             for (type, key) in propertyWrappers {


### PR DESCRIPTION
## As-is

Note: Add `@State` for comparison.

```swift
ContentView(
    flag: @State(false),
   _isLongPressed: GestureState<Bool>(
       state: @State(false),
       reset: (Binding<Bool>) -> ()(
       )
   )
)
```

## To be

```swift
//
// prettyPrint()
//
ContentView(
    flag: false,
    isLongPressed: false
)

//
// prettyPrintDebug
//
ContentView(
    flag: @State(false),
    isLongPressed: @GestureState(false)
)
```