### PR TITLE
support: `@FocucedBinding` of SwiftUI

### DIFF
--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -152,6 +152,7 @@ struct PrettyDescriber {
             "SceneStorage",
             "GestureState",
             "FocusState",
+            "FocusedBinding",
         ].contains { typeName.hasPrefix("\($0)<") }
     }
 
@@ -205,6 +206,19 @@ struct PrettyDescriber {
                     } else {
                         return __string(value)
                     }
+                }
+            }
+
+            //
+            // @FocusedBinding
+            //
+            if typeName.hasPrefix("FocusedBinding<") {
+                // Try lookup `_value` of `@Binding`.
+                let value = lookup("_value", from: target).map(__string) ?? "nil"
+                if debug {
+                    return "@FocusedBinding(\(value))"
+                } else {
+                    return value
                 }
             }
 


### PR DESCRIPTION
## As-is

```swift
PlantCommands(
    _garden: FocusedBinding<Garden>(content: Content.value(nil)),
    _selection: FocusedBinding<Set<UUID>>(content: Content.value(nil))
)
PlantCommands(
    _garden: FocusedBinding<Garden>(content: Content.value(Optional(@Binding(Garden(
        id: "7FF110A8-0A30-4489-9B63-6F51706CF4C9",
        year: 2021,
        name: "New Garden",
        plants: [
        ]
    ))))),
    _selection: FocusedBinding<Set<UUID>>(content: Content.value(Optional(@Binding(Set([
    ])))))
)
```

## To be

### prettyPrint()

```swift
PlantCommands(
    garden: nil,
    selection: nil
)
PlantCommands(
    garden: Garden(
        id: "E4189DA7-2818-44D4-8D42-E52DE4BD70BD",
        year: 2021,
        name: "New Garden",
        plants: [
        ]
    ),
    selection: [
    ]
)
```

### prettyPrintDebug()

```swift
PlantCommands(
    garden: @FocusedBinding(nil),
    selection: @FocusedBinding(nil)
)
PlantCommands(
    garden: @FocusedBinding(Garden(
        id: "97F83CC8-4976-4B76-8048-4D907B7D99F0",
        year: 2021,
        name: "New Garden",
        plants: [
        ]
    )),
    selection: @FocusedBinding(Set([
    ]))
)
```