### PR TITLE
support: `@FocusedValue` of SwiftUI

### DIFF
--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -153,6 +153,7 @@ struct PrettyDescriber {
             "GestureState",
             "FocusState",
             "FocusedBinding",
+            "FocusedValue",
         ].contains { typeName.hasPrefix("\($0)<") }
     }
 
@@ -195,7 +196,8 @@ struct PrettyDescriber {
                 ("EnvironmentObject", "_store"),
                 ("State", "_value"),
                 ("Binding", "_value"),
-                ("GestureState", "_value"), // Lookup @State's value.
+                ("GestureState", "_value"), // Lookup `value` of `@State' type.
+                ("FocusedValue", "value"), // Lookup `value` of `Optional` type.
             ]
 
             for (type, key) in propertyWrappers {


### PR DESCRIPTION
## As-is

```swift
NotePreview(_note: FocusedValue<String>(content: Content.value(nil)))
NotePreview(_note: FocusedValue<String>(content: .value("text")))
```

## To be

### prettyPrint()

```swift
NotePreview(note: "text")
NotePreview(note: nil)
```

### prettyPrintDebug()

```swift
NotePreview(note: @FocusedValue(nil))
NotePreview(note: @FocusedValue(Optional("text")))
```