### PR TITLE
support: `@ScaledMetric` of SwiftUI

### DIFF
--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -101,15 +101,7 @@ struct PrettyDescriber {
         }
 
         // Object
-        let fields: [(String, String)] = mirror.children.map {
-            let value = _string($0.value)
-
-            if isSwiftUIPropertyWrapperType($0.value), let label = $0.label, label.first == "_" {
-                return (String(label.dropFirst()), value) // e.g. `_text` -> `text`
-            } else {
-                return ($0.label ?? "-", value)
-            }
-        }
+        let fields = objectFields(target, debug: debug)
         return formatter.objectString(typeName: typeName, fields: fields)
     }
 
@@ -138,7 +130,18 @@ struct PrettyDescriber {
         }
     }
 
-    func isSwiftUIPropertyWrapperType(_ target: Any) -> Bool {
+    private func objectFields(_ target: Any, debug: Bool) -> [(String, String)] {
+        Mirror(reflecting: target).children.map {
+            let value = string($0.value, debug: debug)
+            if isSwiftUIPropertyWrapperType($0.value), let label = $0.label, label.first == "_" {
+                return (String(label.dropFirst()), value) // e.g. `_text` -> `text`
+            } else {
+                return ($0.label ?? "-", value)
+            }
+        }
+    }
+
+    private func isSwiftUIPropertyWrapperType(_ target: Any) -> Bool {
         let typeName = String(describing: target.self)
         return [
             "Published",

--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -157,6 +157,7 @@ struct PrettyDescriber {
             "FocusState",
             "FocusedBinding",
             "FocusedValue",
+            "ScaledMetric",
         ].contains { typeName.hasPrefix("\($0)<") } || typeName.hasPrefix("Namespace")
     }
 
@@ -212,6 +213,13 @@ struct PrettyDescriber {
                         return __string(value)
                     }
                 }
+            }
+
+            //
+            // @ScaledMetric
+            //
+            if typeName.hasPrefix("ScaledMetric<") {
+                return formatter.objectString(typeName: "@ScaledMetric", fields: objectFields(target, debug: debug))
             }
 
             //


### PR DESCRIPTION
This PR is depended on #187 

## As-is

```swift
ContentView(
    _imageSize: ScaledMetric<Double>(
        dynamicTypeSize: @Environment(DynamicTypeSize.xxxLarge),
        pixelLength: @Environment(0.5),
        value: 100.0,
        textStyle: TextStyle.body
    ),
    _imageSize2: ScaledMetric<Double>(
        dynamicTypeSize: @Environment(DynamicTypeSize.xxxLarge),
        pixelLength: @Environment(0.5),
        value: 100.0,
        textStyle: TextStyle.largeTitle
    )
)
```

## To be

Note: 
No difference in the output of `@ScaledMetric` depending on whether it is debugged or not.

### prettyPrint

```swift
ContentView(
    imageSize: @ScaledMetric(
        dynamicTypeSize: .xxxLarge,
        pixelLength: 0.5,
        value: 100.0,
        textStyle: .body
    ),
    imageSize2: @ScaledMetric(
        dynamicTypeSize: .xxxLarge,
        pixelLength: 0.5,
        value: 100.0,
        textStyle: .largeTitle
    )
)
```

### prettyPrintDebug

```swift
ContentView(
    imageSize: @ScaledMetric(
        dynamicTypeSize: @Environment(DynamicTypeSize.xxxLarge),
        pixelLength: @Environment(0.5),
        value: 100.0,
        textStyle: TextStyle.body
    ),
    imageSize2: @ScaledMetric(
        dynamicTypeSize: @Environment(DynamicTypeSize.xxxLarge),
        pixelLength: @Environment(0.5),
        value: 100.0,
        textStyle: TextStyle.largeTitle
    )
)
```