### PR TITLE
support: `@XXApplicationDelegateAdaptor` of SwiftUI

### DIFF
--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -158,6 +158,8 @@ struct PrettyDescriber {
             "FocusedBinding",
             "FocusedValue",
             "ScaledMetric",
+            "UIApplicationDelegateAdaptor",
+            "NSApplicationDelegateAdaptor",
         ].contains { typeName.hasPrefix("\($0)<") } || typeName.hasPrefix("Namespace")
     }
 
@@ -215,11 +217,14 @@ struct PrettyDescriber {
                 }
             }
 
-            //
-            // @ScaledMetric
-            //
-            if typeName.hasPrefix("ScaledMetric<") {
-                return formatter.objectString(typeName: "@ScaledMetric", fields: objectFields(target, debug: debug))
+            let replaceTypeNames: [String] = [
+                "ScaledMetric",
+                "UIApplicationDelegateAdaptor",
+                "NSApplicationDelegateAdaptor",
+            ]
+
+            for name in replaceTypeNames where typeName.hasPrefix("\(name)<") {
+                return formatter.objectString(typeName: "@\(name)", fields: objectFields(target, debug: debug))
             }
 
             //


### PR DESCRIPTION
NSObject is not supports in SwiftPrettyPrint currently. ( #112 )
Therefore this PR is intended to provide sense of unity of other property-wrappers that supports in SwiftPrettyPrint.

## As-is

```swift
AlignmentGuideApp(
    _appDelegate: UIApplicationDelegateAdaptor<AppDelegate>(
    ),
    message: @State("Hello")
)

AlignmentGuideApp(
    _appDelegate: NSApplicationDelegateAdaptor<AppDelegate>(
    ),
    message: @State("Hello")
)
```

## To be

Note:
No difference in the output of `@XXApplicationDelegateAdaptor` depending on whether debug or not.

```swift
AlignmentGuideApp(
    appDelegate: @NSApplicationDelegateAdaptor(
    ),
    message: @State("Hello")
)

AlignmentGuideApp(
    appDelegate: @UIApplicationDelegateAdaptor(
    ),
    message: @State("Hello")
)
```