### PR TITLE
temporary support: `@FetchRequest`

### DIFF
--- a/Sources/Core/PrettyDescriber.swift
+++ b/Sources/Core/PrettyDescriber.swift
@@ -160,6 +160,7 @@ struct PrettyDescriber {
             "ScaledMetric",
             "UIApplicationDelegateAdaptor",
             "NSApplicationDelegateAdaptor",
+            "FetchRequest",
         ].contains { typeName.hasPrefix("\($0)<") } || typeName.hasPrefix("Namespace")
     }
 
@@ -227,6 +228,19 @@ struct PrettyDescriber {
                 return formatter.objectString(typeName: "@\(name)", fields: objectFields(target, debug: debug))
             }
 
+            let notSupportedTypes: [String] = [
+                "FocusState", // Currently not getting values, but implemented to prevent infinite loops.
+                "FetchRequest", // No useful value can be obtained at currently, but the output should not be disturbing.
+            ]
+
+            for name in notSupportedTypes where typeName.hasPrefix("\(name)<") {
+                if debug {
+                    return "@\(name)(<can not lookup>)"
+                } else {
+                    return "<can not lookup>"
+                }
+            }
+
             //
             // @Namespace
             //
@@ -249,20 +263,6 @@ struct PrettyDescriber {
                     return "@FocusedBinding(\(value))"
                 } else {
                     return value
-                }
-            }
-
-            //
-            // @FocusState
-            //
-            // Note: Currently not getting values, but implemented to prevent infinite loops.
-            //
-            if typeName.hasPrefix("FocusState<") {
-                // TODO: I don't know where to get the value of what's inside.
-                if debug {
-                    return "@FocusState(<can not lookup>)"
-                } else {
-                    return "<can not lookup>"
                 }
             }
 


### PR DESCRIPTION
No useful value can be obtained from `@FetchRequest` at currently SwiftPrettyPrint strategy. (maybe)
But the output is disturbing currently, therefore temporary support in this PR.

## As-is

```swift
ContentView(
    viewContext: @Environment(<NSManagedObjectContext: 0x600001960340>),
    _items: FetchRequest<Item>(
        managedObjectContext: @Environment(<NSManagedObjectContext: 0x600001960340>),
        controller: @StateObject(<_TtGC7SwiftUI15FetchControllerT_C15CoreDataSandbox4ItemGVS_14FetchedResultsS2___: 0x600000679080>),
        results: @State(nil),
        transaction: Transaction(plist: [Key<AnimationKey> = Optional(AnyAnimator(SwiftUI.BezierAnimation(duration: 0.35, curve: SwiftUI.(unknown context at $7fff5df354c0).BezierTimingCurve(ax: 0.52, bx: -0.78, cx: 1.26, ay: -2.0, by: 3.0, cy: 0.0))))]),
        deferredFetchRequest: DeferredFetchRequest<Item>(
            $__lazy_storage_$_result: Optional(<NSFetchRequest: 0x600000971650> (entity: Item; predicate: ((null)); sortDescriptors: ((
                "(timestamp, ascending, NO, compare:)"
            )); type: NSManagedObjectResultType; )),
            resolve: () -> NSFetchRequest(
            )
        )
    )
)
```

## To be

### prettyPrint

```swift
ContentView(
    viewContext: <NSManagedObjectContext: 0x6000026b0680>,
    items: <can not lookup>
)
```

### prettyPrintDebug

```swift
ContentView(
    viewContext: @Environment(<NSManagedObjectContext: 0x6000026b0680>),
    items: @FetchRequest(<can not lookup>)
)
```