### PR TITLE
fix to make the string being attached to  coloredLogStream colored again

### DIFF
--- a/Sources/Public/Pretty.swift
+++ b/Sources/Public/Pretty.swift
@@ -306,12 +306,8 @@ extension Pretty {
     ) {
         let plainString = printer(label, targets, separator, option)
 
-        let coloredOption: Option = {
-            var op = option
-            op.colored = true
-            return op
-        }()
-
+        var coloredOption = option
+        coloredOption.colored = true
         let coloredString = printer(label, targets, separator, coloredOption)
 
         // Console

--- a/Sources/Public/Pretty.swift
+++ b/Sources/Public/Pretty.swift
@@ -305,7 +305,14 @@ extension Pretty {
         option: Option
     ) {
         let plainString = printer(label, targets, separator, option)
-        let coloredString = printer(label, targets, separator, option)
+
+        let coloredOption: Option = {
+            var op = option
+            op.colored = true
+            return op
+        }()
+
+        let coloredString = printer(label, targets, separator, coloredOption)
 
         // Console
         Swift.print(option.colored ? coloredString : plainString)


### PR DESCRIPTION
Fixed a bug caused in PR #165 and #173 where strings for `output-colored.log` were no longer colored.

this fixes #184.