### PR TITLE
Remove specification of Xcode version from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release to CocoaPods
 # 
 # - unit-test:        Run all tests on latest macOS and Xcode.
 # - unit-test-linux:  Run tests on Linux (Swift 5.1) - Not include the Combine extension tests.
-# - integration-test: Run integration test by Xcode 11.3.1 and Swift 5.1.3 with CocoaPods.
+# - integration-test: Run integration test using latest stable Xcode and Swift with CocoaPods. 
 #
 
 on:
@@ -48,10 +48,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Select Xcode 11.3.1
-      run: |
-        sudo xcode-select -s '/Applications/Xcode_11.3.1.app/Contents/Developer'
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+    - name: Select latest stable Xcode
+      run:
         xcodebuild -version
 
     - name: Cache bundler


### PR DESCRIPTION
# motivation

Prevent errors which have occured in the process of releasing v1.4.0 :
https://github.com/YusukeHosonuma/SwiftPrettyPrint/actions/runs/2362187422

# proposed solution

Remove specification of concrete version of Xcode using [setup-xcode](https://github.com/maxim-lobanov/setup-xcode).